### PR TITLE
Update to Serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ version = "0.1.2"
 
 [dependencies]
 log = "0.3.6"
-serde = "0.9.7"
+serde = "1.0"
 xml-rs = "0.3.6"
 
 [dev-dependencies]
-serde_derive = "0.9.7"
+serde_derive = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,15 +1,16 @@
 use xml::reader;
 use std::fmt::{self, Display, Debug};
 use std::error::Error as StdError;
+use std::num;
 use serde::de::Error as SerdeError;
-use serde::de::Visitor;
 
 pub enum Error {
+    ParseIntError(num::ParseIntError),
     Syntax(reader::Error),
     Custom(String)
 }
 
-pub type VResult<V> = Result<<V as Visitor>::Value, Error>;
+pub type VResult<V> = Result<V, Error>;
 
 macro_rules! expect {
     ($actual: expr, $($expected: pat)|+ => $if_ok: expr) => {
@@ -43,6 +44,7 @@ macro_rules! debug_expect {
 impl Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Error::ParseIntError(ref error) => Display::fmt(error, fmt),
             Error::Syntax(ref error) => Display::fmt(error, fmt),
             Error::Custom(ref display) => Display::fmt(display, fmt)
         }
@@ -52,6 +54,7 @@ impl Display for Error {
 impl Debug for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Error::ParseIntError(ref error) => Display::fmt(error, fmt),
             Error::Syntax(ref error) => Debug::fmt(error, fmt),
             Error::Custom(ref display) => Display::fmt(display, fmt)
         }
@@ -61,6 +64,7 @@ impl Debug for Error {
 impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
+            Error::ParseIntError(ref error) => error.description(),
             Error::Syntax(ref error) => error.description(),
             Error::Custom(_) => "other error"
         }
@@ -68,6 +72,7 @@ impl StdError for Error {
 
     fn cause(&self) -> Option<&StdError> {
         match *self {
+            Error::ParseIntError(ref error) => Some(error),
             Error::Syntax(ref error) => Some(error),
             _ => None
         }

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,18 +3,18 @@ use xml::attribute::OwnedAttribute;
 use xml::reader::XmlEvent;
 use {Deserializer, Error, VResult};
 use serde::de::{self, DeserializeSeed, Visitor};
-use serde::de::value::ValueDeserializer;
+use serde::de::IntoDeserializer;
 
-pub struct MapVisitor<'a, R: 'a + Read> {
+pub struct MapAccess<'a, R: 'a + Read> {
     attrs: ::std::vec::IntoIter<OwnedAttribute>,
     next_value: Option<String>,
     de: &'a mut Deserializer<R>,
     inner_value: bool
 }
 
-impl<'a, R: 'a + Read> MapVisitor<'a, R> {
+impl<'a, R: 'a + Read> MapAccess<'a, R> {
     pub fn new(de: &'a mut Deserializer<R>, attrs: Vec<OwnedAttribute>, inner_value: bool) -> Self {
-        MapVisitor {
+        MapAccess {
             attrs: attrs.into_iter(),
             next_value: None,
             de: de,
@@ -23,10 +23,10 @@ impl<'a, R: 'a + Read> MapVisitor<'a, R> {
     }
 }
 
-impl<'a, R: 'a + Read> de::MapVisitor for MapVisitor<'a, R> {
+impl<'de, 'a, R: 'a + Read> de::MapAccess<'de> for MapAccess<'a, R> {
     type Error = Error;
 
-    fn visit_key_seed<K: DeserializeSeed>(&mut self, seed: K) -> Result<Option<K::Value>, Error> {
+    fn next_key_seed<K: DeserializeSeed<'de>>(&mut self, seed: K) -> Result<Option<K::Value>, Error> {
         debug_assert_eq!(self.next_value, None);
         match self.attrs.next() {
             Some(OwnedAttribute { name, value }) => {
@@ -51,7 +51,7 @@ impl<'a, R: 'a + Read> de::MapVisitor for MapVisitor<'a, R> {
         }
     }
 
-    fn visit_value_seed<V: DeserializeSeed>(&mut self, seed: V) -> Result<V::Value, Error> {
+    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, Error> {
         match self.next_value.take() {
             Some(value) => seed.deserialize(AttrValueDeserializer(value)),
             None => {
@@ -66,35 +66,40 @@ impl<'a, R: 'a + Read> de::MapVisitor for MapVisitor<'a, R> {
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.attrs.size_hint().0, None)
+    fn size_hint(&self) -> Option<usize> {
+        self.attrs.size_hint().1
     }
 }
 
 struct AttrValueDeserializer(String);
 
-impl de::Deserializer for AttrValueDeserializer {
+impl<'de> de::Deserializer<'de> for AttrValueDeserializer {
     type Error = Error;
 
-    fn deserialize<V: Visitor>(self, visitor: V) -> VResult<V> {
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> VResult<V::Value> {
         visitor.visit_string(self.0)
     }
 
-    fn deserialize_enum<V: Visitor>(self, _name: &str, _variants: &'static [&'static str], visitor: V) -> VResult<V> {
+    fn deserialize_u8<V: de::Visitor<'de>>(self, visitor: V) -> VResult<V::Value> {
+        let u = self.0.parse().map_err(Error::ParseIntError)?;
+        visitor.visit_u8(u)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(self, _name: &str, _variants: &'static [&'static str], visitor: V) -> VResult<V::Value> {
         visitor.visit_enum(self.0.into_deserializer())
     }
 
-    fn deserialize_option<V: Visitor>(self, visitor: V) -> VResult<V> {
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> VResult<V::Value> {
         visitor.visit_some(self)
     }
 
-    fn deserialize_bool<V: Visitor>(self, visitor: V) -> VResult<V> {
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> VResult<V::Value> {
         visitor.visit_bool(!self.0.is_empty())
     }
 
-    forward_to_deserialize! {
-        u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit
-        seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple ignored_any byte_buf
+    forward_to_deserialize_any! {
+        u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit
+        seq bytes map unit_struct newtype_struct tuple_struct
+        struct identifier tuple ignored_any byte_buf
     }
 }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -3,13 +3,13 @@ use xml::reader::XmlEvent;
 use {Deserializer, Error};
 use serde::de::{self, DeserializeSeed};
 
-pub struct SeqVisitor<'a, R: 'a + Read> {
+pub struct SeqAccess<'a, R: 'a + Read> {
     de: &'a mut Deserializer<R>,
     max_size: Option<usize>,
     expected_name: Option<String>
 }
 
-impl<'a, R: 'a + Read> SeqVisitor<'a, R> {
+impl<'a, R: 'a + Read> SeqAccess<'a, R> {
     pub fn new(de: &'a mut Deserializer<R>, max_size: Option<usize>) -> Self {
         let expected_name = if de.unset_map_value() {
             debug_expect!(de.peek(), Ok(&XmlEvent::StartElement { ref name, .. }) => {
@@ -18,7 +18,7 @@ impl<'a, R: 'a + Read> SeqVisitor<'a, R> {
         } else {
             None
         };
-        SeqVisitor {
+        SeqAccess {
             de: de,
             max_size: max_size,
             expected_name: expected_name
@@ -26,10 +26,10 @@ impl<'a, R: 'a + Read> SeqVisitor<'a, R> {
     }
 }
 
-impl<'a, R: 'a + Read> de::SeqVisitor for SeqVisitor<'a, R> {
+impl<'de, 'a, R: 'a + Read> de::SeqAccess<'de> for SeqAccess<'a, R> {
     type Error = Error;
 
-    fn visit_seed<T: DeserializeSeed>(&mut self, seed: T) -> Result<Option<T::Value>, Error> {
+    fn next_element_seed<T: DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>, Error> {
         match self.max_size.as_mut() {
             Some(&mut 0) => {
                 return Ok(None);
@@ -57,7 +57,7 @@ impl<'a, R: 'a + Read> de::SeqVisitor for SeqVisitor<'a, R> {
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, self.max_size)
+    fn size_hint(&self) -> Option<usize> {
+        self.max_size
     }
 }

--- a/src/var.rs
+++ b/src/var.rs
@@ -3,50 +3,50 @@ use xml::name::OwnedName;
 use xml::reader::XmlEvent;
 use {Deserializer, Error};
 use serde::de::{self, DeserializeSeed, Deserializer as SerdeDeserializer, Visitor, Error as SerdeError};
-use serde::de::value::ValueDeserializer;
+use serde::de::IntoDeserializer;
 use VResult;
 
-pub struct EnumVisitor<'a, R: 'a + Read> {
+pub struct EnumAccess<'a, R: 'a + Read> {
     de: &'a mut Deserializer<R>
 }
 
-impl<'a, R: 'a + Read> EnumVisitor<'a, R> {
+impl<'a, R: 'a + Read> EnumAccess<'a, R> {
     pub fn new(de: &'a mut Deserializer<R>) -> Self {
-        EnumVisitor {
+        EnumAccess {
             de: de
         }
     }
 }
 
-impl<'a, R: 'a + Read> de::EnumVisitor for EnumVisitor<'a, R> {
+impl<'de, 'a, R: 'a + Read> de::EnumAccess<'de> for EnumAccess<'a, R> {
     type Error = Error;
-    type Variant = VariantVisitor<'a, R>;
+    type Variant = VariantAccess<'a, R>;
 
-    fn visit_variant_seed<V: DeserializeSeed>(self, seed: V) -> Result<(V::Value, VariantVisitor<'a, R>), Error> {
+    fn variant_seed<V: DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, VariantAccess<'a, R>), Error> {
         let name = expect!(self.de.peek()?, &XmlEvent::Characters(ref name) | &XmlEvent::StartElement { name: OwnedName { local_name: ref name, .. }, .. } => {
             seed.deserialize(name.as_str().into_deserializer())
         })?;
         self.de.set_map_value();
-        Ok((name, VariantVisitor::new(self.de)))
+        Ok((name, VariantAccess::new(self.de)))
     }
 }
 
-pub struct VariantVisitor<'a, R: 'a + Read> {
+pub struct VariantAccess<'a, R: 'a + Read> {
     de: &'a mut Deserializer<R>
 }
 
-impl<'a, R: 'a + Read> VariantVisitor<'a, R> {
+impl<'a, R: 'a + Read> VariantAccess<'a, R> {
     pub fn new(de: &'a mut Deserializer<R>) -> Self {
-        VariantVisitor {
+        VariantAccess {
             de: de
         }
     }
 }
 
-impl<'a, R: 'a + Read> de::VariantVisitor for VariantVisitor<'a, R> {
+impl<'de, 'a, R: 'a + Read> de::VariantAccess<'de> for VariantAccess<'a, R> {
     type Error = Error;
 
-    fn visit_unit(self) -> Result<(), Error> {
+    fn unit_variant(self) -> Result<(), Error> {
         self.de.unset_map_value();
         match self.de.next()? {
             XmlEvent::StartElement { name, attributes, .. } => {
@@ -63,15 +63,15 @@ impl<'a, R: 'a + Read> de::VariantVisitor for VariantVisitor<'a, R> {
         }
     }
 
-    fn visit_newtype_seed<T: DeserializeSeed>(self, seed: T) -> Result<T::Value, Error> {
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(self, seed: T) -> Result<T::Value, Error> {
         seed.deserialize(&mut *self.de)
     }
 
-    fn visit_tuple<V: Visitor>(self, len: usize, visitor: V) -> VResult<V> {
+    fn tuple_variant<V: Visitor<'de>>(self, len: usize, visitor: V) -> VResult<V::Value> {
         self.de.deserialize_tuple(len, visitor)
     }
 
-    fn visit_struct<V: Visitor>(self, _fields: &'static [&'static str], visitor: V) -> VResult<V> {
+    fn struct_variant<V: Visitor<'de>>(self, _fields: &'static [&'static str], visitor: V) -> VResult<V::Value> {
         self.de.deserialize_map(visitor)
     }
 }

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 use serde_xml_rs::{deserialize, Error};
 use serde::{ser, de};
 
-fn from_str<T: de::Deserialize>(s: &str) -> Result<T, Error> {
+fn from_str<'de, T: de::Deserialize<'de>>(s: &str) -> Result<T, Error> {
     deserialize(s.as_bytes())
 }
 
@@ -44,8 +44,8 @@ struct Outer {
     inner: Option<Inner>,
 }
 
-fn test_parse_ok<'a, T>(errors: &[(&'a str, T)])
-where T: PartialEq + Debug + ser::Serialize + de::Deserialize,
+fn test_parse_ok<'de, 'a, T>(errors: &[(&'a str, T)])
+where T: PartialEq + Debug + ser::Serialize + de::Deserialize<'de>,
 {
     for &(s, ref value) in errors {
         let v: T = from_str(s).unwrap();
@@ -60,8 +60,8 @@ where T: PartialEq + Debug + ser::Serialize + de::Deserialize,
     }
 }
 
-fn test_parse_err<'a, T>(errors: &[&'a str])
-    where T: PartialEq + Debug + ser::Serialize + de::Deserialize,
+fn test_parse_err<'de, 'a, T>(errors: &[&'a str])
+    where T: PartialEq + Debug + ser::Serialize + de::Deserialize<'de>,
 {
     for &s in errors {
         assert!(match from_str::<T>(s) {
@@ -580,11 +580,11 @@ fn test_hugo_duncan2() {
     }
 
     #[derive(PartialEq, Debug, Serialize)]
-    struct ItemVec<T: de::Deserialize>(Vec<T>);
+    struct ItemVec<T>(Vec<T>);
 
-    impl<T: de::Deserialize> de::Deserialize for ItemVec<T> {
+    impl<'de, T: de::Deserialize<'de>> de::Deserialize<'de> for ItemVec<T> {
         fn deserialize<D>(deserializer: D) -> Result<ItemVec<T>, D::Error>
-            where D: de::Deserializer,
+            where D: de::Deserializer<'de>,
         {
             #[derive(PartialEq, Debug, Serialize, Deserialize)]
             struct Helper<U> {


### PR DESCRIPTION
This is similar to #10, but makes fewer changes, implements a cleaner version of `parse_int`, and avoids a potential infinite recursion involving `deserialize_tuple`.

Some `deserialize_u8/u16/etc` methods were added or changed to resolve test failure regressions. A few others were added/changed to further reduce the number of test failures in line with #10 (these changes may be slightly out of scope). Unlike #10, I didn't add/change all such methods: while the full set of them should probably be implemented consistently, those I left unimplemented/unchanged don't seem to have any test coverage, so I think making those changes is significantly out of scope for this PR.