### PR TITLE
Added support for serializing sequences of things

### DIFF
--- a/src/ser/helpers.rs
+++ b/src/ser/helpers.rs
@@ -1,0 +1,19 @@
+use serde::ser::Serialize;
+use ser::to_string;
+
+/// In XML, various things can only be serialized if they are (or aren't)
+/// primitive types. This is a **hack** to try and detect this.
+pub fn is_primitive<S>(thing: &S) -> bool
+where
+    S: Serialize + ?Sized,
+{
+    let contains_xml_characters = match to_string(&thing) {
+        Ok(repr) => repr.contains("<") && repr.contains(">") && repr.contains("</"),
+
+        // if we can't serialize the caller will return an error anyway so
+        // it doesn't matter what we return here.
+        Err(_) => false,
+    };
+
+    !contains_xml_characters
+}

--- a/src/ser/helpers.rs
+++ b/src/ser/helpers.rs
@@ -1,19 +1,322 @@
-use serde::ser::Serialize;
-use ser::to_string;
+use serde::ser::{Impossible, Serialize, Serializer, Error as SerError};
+use error::Error;
 
-/// In XML, various things can only be serialized if they are (or aren't)
-/// primitive types. This is a **hack** to try and detect this.
-pub fn is_primitive<S>(thing: &S) -> bool
+
+/// Check if a value would be "wrapped" when serialized as XML. 
+///
+/// As a rule of thumb, if something **isn't** wrapped then the XML serialized
+/// version would look similar to what you get from `Display`. Wrapped things 
+/// typically look like `<foo>...</foo>`.
+pub fn is_wrapped<S>(thing: &S) -> bool
 where
     S: Serialize + ?Sized,
 {
-    let contains_xml_characters = match to_string(&thing) {
-        Ok(repr) => repr.contains("<") && repr.contains(">") && repr.contains("</"),
+    let mut is_wrapped = false;
 
-        // if we can't serialize the caller will return an error anyway so
-        // it doesn't matter what we return here.
-        Err(_) => false,
-    };
+    thing.serialize(WrapSafeDetector{ is_wrapped: &mut is_wrapped }).ok();
 
-    !contains_xml_characters
+    is_wrapped
+}
+
+#[derive(Debug)]
+struct WrapSafeDetector<'a> {
+    is_wrapped: &'a mut bool,
+}
+
+#[allow(unused_variables)]
+impl<'a> Serializer for WrapSafeDetector<'a> {
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = false;
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = true;
+        Ok(())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = true;
+        Ok(())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = true;
+        Ok(())
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        *self.is_wrapped = true;
+        Ok(())
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        // FIXME: Is a sequence of sequences okay here?
+        *self.is_wrapped = false;
+        Err(Error::custom("Ignore me...".to_string()))
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        // FIXME: I think a tuple counts as a "primitive"... doesn't it?
+        *self.is_wrapped = false;
+        Err(Error::custom("Ignore me...".to_string()))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        *self.is_wrapped = true;
+        Err(Error::custom("Ignore me...".to_string()))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        *self.is_wrapped = true;
+        Err(Error::custom("Ignore me...".to_string()))
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        *self.is_wrapped = true;
+        Err(Error::custom("Ignore me...".to_string()))
+    }
+
+    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct, Self::Error> {
+        *self.is_wrapped = true;
+        Err(Error::custom("Ignore me...".to_string()))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        *self.is_wrapped = true;
+        Err(Error::custom("Ignore me...".to_string()))
+    }
+}
+
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod tests {
+    use super::*;
+
+    macro_rules! prim_check {
+        ($name:ident, $ty:path) => {
+            #[test]
+            fn $name() {
+                let v: $ty = 0 as $ty;
+                assert!(!is_wrapped(&v));
+            }
+        }
+    }
+
+    prim_check!(check_u8_is_primitive, u8);
+    prim_check!(check_i8_is_primitive, i8);
+    prim_check!(check_u16_is_primitive, u16);
+    prim_check!(check_i16_is_primitive, i16);
+    prim_check!(check_u32_is_primitive, u32);
+    prim_check!(check_i32_is_primitive, i32);
+    prim_check!(check_u64_is_primitive, u64);
+    prim_check!(check_i64_is_primitive, i64);
+    prim_check!(check_f32_is_primitive, f32);
+    prim_check!(check_f64_is_primitive, f64);
+
+    #[derive(Default, Serialize)]
+    struct UnitStruct;
+
+    #[derive(Default, Serialize)]
+    struct Newtype(u32);
+
+    #[derive(Default, Serialize)]
+    struct TupleStruct(u32, bool);
+
+    #[derive(Default, Serialize)]
+    struct NormalStruct {
+        x: u32,
+        y: u32,
+    }
+
+    macro_rules! struct_check {
+        ($name:ident, $ty:path) => {
+            #[test]
+            fn $name() {
+                let value: $ty = Default::default();
+
+                assert!(is_wrapped(&value));
+            }
+        }
+    }
+
+    struct_check!(check_unit_struct, UnitStruct);
+    struct_check!(check_newtype_struct, Newtype);
+    struct_check!(check_tuple_struct, TupleStruct);
+    struct_check!(check_normal_struct, NormalStruct);
+
+    #[derive(Serialize)]
+    enum BoringEnum {
+        A, 
+        B,
+    }
+
+    #[derive(Serialize)]
+    enum BasicRustEnum {
+        A(u32), 
+        B(f64),
+    }
+
+    #[derive(Serialize)]
+    enum StructEnum {
+        A{ x: u32, y: u32 },
+    }
+
+    macro_rules! enum_check {
+        ($name:ident, $init:expr) => {
+            #[test]
+            fn $name() {
+                let value = $init;
+                assert!(is_wrapped(&value));
+            }
+        }
+    }
+
+    enum_check!(check_c_style_enum, BoringEnum::A);
+    enum_check!(check_basic_rust_style_enum, BasicRustEnum::A(5));
+    enum_check!(check_struct_enum, StructEnum::A{x: 1, y: 2});
+
+    #[test]
+    fn check_unit_is_primitive() {
+        assert!(!is_wrapped(&()));
+    }
+
+    #[test]
+    fn check_some_of_primitive_is_primitive() {
+        assert!(!is_wrapped(&Some(42)));
+    }
+
+    #[test]
+    fn check_none_is_primitive() {
+        let value: Option<u32> = None;
+        assert!(!is_wrapped(&value));
+    }
+
+    #[test]
+    fn check_vec_of_primitives_isnt_wrapped() {
+        let value = vec![1_u32, 2, 3, 4];
+        assert!(!is_wrapped(&value));
+    }
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -218,9 +218,7 @@ where
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok> {
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_newtype_struct".to_string()).into(),
-        )
+        self.write_wrapped(name, value)
     }
 
     fn serialize_newtype_variant<T: ?Sized + Serialize>(
@@ -417,5 +415,20 @@ mod tests {
         let got = String::from_utf8(buffer).unwrap();
         println!("{}", got);
         panic!();
+    }
+
+    #[test]
+    fn newtype_struct() {
+        #[derive(Serialize)]
+        struct Foo(u32);
+
+        let f = Foo(5);
+        let should_be = "<Foo>5</Foo>";
+
+        let mut buffer = Vec::new();
+        f.serialize(&mut Serializer::new(&mut buffer)).unwrap();
+
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!(got, should_be);
     }
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -6,7 +6,7 @@ use serde::ser::{self, Impossible, Serialize};
 use error::{Error, ErrorKind, Result};
 use self::var::{Map, Struct};
 use self::seq::Seq;
-use self::tuples::{Tuple, TupleStruct};
+use self::tuples::Tuple;
 
 mod var;
 mod seq;
@@ -119,7 +119,7 @@ where
 
     type SerializeSeq = Seq<'w, W>;
     type SerializeTuple = Tuple<'w, W>;
-    type SerializeTupleStruct = TupleStruct<'w, W>;
+    type SerializeTupleStruct = Tuple<'w, W>;
     type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
     type SerializeMap = Map<'w, W>;
     type SerializeStruct = Struct<'w, W>;
@@ -250,7 +250,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
         write!(self.writer, "<{}>", name)?;
-        Ok(TupleStruct::new(self, name))
+        Ok(Tuple::new_with_name(self, name))
     }
 
     fn serialize_tuple_variant(

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -9,6 +9,7 @@ use self::seq::Seq;
 
 mod var;
 mod seq;
+mod helpers;
 
 
 /// A convenience method for serializing some object to a buffer.
@@ -409,11 +410,7 @@ mod tests {
         let should_be = "<Foo></Foo><Foo></Foo><Foo></Foo>";
 
         let mut buffer = Vec::new();
-
-        {
-            let mut ser = Serializer::new(&mut buffer);
-            inputs.serialize(&mut ser).unwrap();
-        }
+        inputs.serialize(&mut Serializer::new(&mut buffer)).unwrap();
 
         let got = String::from_utf8(buffer).unwrap();
         assert_eq!(got, should_be);
@@ -480,5 +477,15 @@ mod tests {
 
         let got = String::from_utf8(buffer).unwrap();
         assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn serializing_a_list_of_primitives_is_an_error() {
+        let dodgy = vec![1, 2, 3, 4, 5];
+
+        let mut buffer = Vec::new();
+        let got = dodgy.serialize(&mut Serializer::new(&mut buffer));
+
+        assert!(got.is_err());
     }
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,12 +1,14 @@
 use std::io::Write;
 use std::fmt::Display;
 
-use serde::ser::{self, Impossible, Serialize, SerializeSeq};
+use serde::ser::{self, Impossible, Serialize};
 
 use error::{Error, ErrorKind, Result};
 use self::var::{Map, Struct};
+use self::seq::Seq;
 
 mod var;
+mod seq;
 
 
 /// A convenience method for serializing some object to a buffer.
@@ -232,7 +234,7 @@ where
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        Ok(Seq { parent: self })
+        Ok(Seq::new(self))
     }
 
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
@@ -280,26 +282,6 @@ where
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         Err(ErrorKind::UnsupportedOperation("Result".to_string()).into())
-    }
-}
-
-pub struct Seq<'a, W: 'a + Write> {
-    parent: &'a mut Serializer<W>,
-}
-
-impl<'a, W: Write> SerializeSeq for Seq<'a, W> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<Self::Ok>
-    where
-        T: Serialize,
-    {
-        value.serialize(&mut *self.parent)
-    }
-
-    fn end(self) -> Result<Self::Ok> {
-        Ok(())
     }
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -292,6 +292,7 @@ mod tests {
     use super::*;
     use serde::Serializer as SerSerializer;
     use serde::ser::{SerializeMap, SerializeStruct};
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_serialize_bool() {
@@ -418,12 +419,60 @@ mod tests {
     }
 
     #[test]
-    fn newtype_struct() {
+    fn basic_newtype_struct() {
         #[derive(Serialize)]
         struct Foo(u32);
 
         let f = Foo(5);
         let should_be = "<Foo>5</Foo>";
+
+        let mut buffer = Vec::new();
+        f.serialize(&mut Serializer::new(&mut buffer)).unwrap();
+
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn option_as_a_newtype_struct() {
+        #[derive(Serialize)]
+        struct Foo(Option<u32>);
+
+        let inputs = vec![(Foo(Some(5)), "<Foo>5</Foo>"), (Foo(None), "<Foo></Foo>")];
+
+        for (input, should_be) in inputs {
+            let mut buffer = Vec::new();
+            input.serialize(&mut Serializer::new(&mut buffer)).unwrap();
+
+            let got = String::from_utf8(buffer).unwrap();
+            assert_eq!(got, should_be);
+        }
+    }
+
+    #[test]
+    fn newtype_wrapper_around_a_map() {
+        #[derive(Serialize)]
+        struct Foo(BTreeMap<String, u32>);
+
+        let pairs = vec![(String::from("a"), 5), (String::from("hello"), 42)];
+        let map = Foo(pairs.into_iter().collect());
+
+        let should_be = "<Foo><a>5</a><hello>42</hello></Foo>";
+        let mut buffer = Vec::new();
+
+        map.serialize(&mut Serializer::new(&mut buffer)).unwrap();
+
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn newtype_around_unit() {
+        #[derive(Serialize)]
+        struct Foo(());
+
+        let should_be = "<Foo></Foo>";
+        let f = Foo(());
 
         let mut buffer = Vec::new();
         f.serialize(&mut Serializer::new(&mut buffer)).unwrap();

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -282,7 +282,7 @@ where
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        Err(ErrorKind::UnsupportedOperation("Result".to_string()).into())
+        Err(ErrorKind::UnsupportedOperation("serialize_struct_variant".to_string()).into())
     }
 }
 

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -23,15 +23,15 @@ impl<'a, W: Write> SerializeSeq for Seq<'a, W> {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<Self::Ok>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         if helpers::is_wrapped(value) {
             value.serialize(&mut *self.parent)
         } else {
             Err(SerError::custom(
-                "Cannot serialize a sequence of primitives",
+                "Cannot serialize a sequence of primitives. Please wrap them in newtypes",
             ))
         }
     }

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -27,12 +27,12 @@ impl<'a, W: Write> SerializeSeq for Seq<'a, W> {
     where
         T: Serialize,
     {
-        if helpers::is_primitive(value) {
+        if helpers::is_wrapped(value) {
+            value.serialize(&mut *self.parent)
+        } else {
             Err(SerError::custom(
                 "Cannot serialize a sequence of primitives",
             ))
-        } else {
-            value.serialize(&mut *self.parent)
         }
     }
 

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -1,0 +1,35 @@
+use std::io::Write;
+use serde::ser::{Serialize, SerializeSeq};
+
+use ser::Serializer;
+use error::{Error, Result};
+
+pub struct Seq<'a, W: 'a + Write> {
+    parent: &'a mut Serializer<W>,
+}
+
+
+impl<'w, W> Seq<'w, W>
+where
+    W: 'w + Write,
+{
+    pub fn new(parent: &'w mut Serializer<W>) -> Seq<'w, W> {
+        Seq { parent }
+    }
+}
+
+impl<'a, W: Write> SerializeSeq for Seq<'a, W> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut *self.parent)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(())
+    }
+}

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -1,7 +1,8 @@
 use std::io::Write;
-use serde::ser::{Serialize, SerializeSeq};
+use serde::ser::{Error as SerError, Serialize, SerializeSeq};
 
 use ser::Serializer;
+use ser::helpers;
 use error::{Error, Result};
 
 pub struct Seq<'a, W: 'a + Write> {
@@ -26,7 +27,13 @@ impl<'a, W: Write> SerializeSeq for Seq<'a, W> {
     where
         T: Serialize,
     {
-        value.serialize(&mut *self.parent)
+        if helpers::is_primitive(value) {
+            Err(SerError::custom(
+                "Cannot serialize a sequence of primitives",
+            ))
+        } else {
+            value.serialize(&mut *self.parent)
+        }
     }
 
     fn end(self) -> Result<Self::Ok> {

--- a/src/ser/tuples.rs
+++ b/src/ser/tuples.rs
@@ -1,0 +1,45 @@
+use std::io::Write;
+use serde::ser::{Error as SerError, Serialize, SerializeTuple};
+
+use ser::Serializer;
+use ser::helpers;
+use error::Error;
+
+pub struct Tuple<'a, W: 'a + Write> {
+    parent: &'a mut Serializer<W>,
+}
+
+
+impl<'w, W> Tuple<'w, W>
+where
+    W: 'w + Write,
+{
+    pub fn new(parent: &'w mut Serializer<W>) -> Tuple<'w, W> {
+        Tuple { parent }
+    }
+}
+
+impl<'w, W> SerializeTuple for Tuple<'w, W>
+where
+    W: 'w + Write
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok, Self::Error> 
+    where 
+        T: Serialize + ?Sized 
+    {
+        if helpers::is_wrapped(value) {
+            value.serialize(&mut *self.parent)
+        } else {
+            Err(SerError::custom(
+                "Tuples can't contain primitive types. Please wrap primitives in a newtype.",
+            ))
+        }
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}

--- a/src/ser/tuples.rs
+++ b/src/ser/tuples.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
-use serde::ser::{Error as SerError, Serialize, SerializeTuple, SerializeTupleStruct};
+use serde::ser::{Error as SerError, Serialize, SerializeTuple, 
+                 SerializeTupleStruct, SerializeTupleVariant};
 
 use ser::Serializer;
 use ser::helpers;
@@ -66,6 +67,26 @@ where
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
         write!(self.parent.writer, "</{}>", self.name.expect("if we're serializing a tuple struct we should have been given a name"))?;
+        Ok(())
+    }
+}
+
+impl<'w, W> SerializeTupleVariant for Tuple<'w, W>
+where
+    W: 'w + Write
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<Self::Ok, Self::Error> 
+    where 
+        T: Serialize + ?Sized 
+    {
+        self.serialize_element(value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        write!(self.parent.writer, "</{}>", self.name.expect("if we're serializing a tuple variant we should have been given a name"))?;
         Ok(())
     }
 }

--- a/src/ser/var.rs
+++ b/src/ser/var.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use serde::ser::{self, Serialize};
+use serde::ser::{self, Serialize, SerializeStruct, SerializeStructVariant};
 
 use ser::Serializer;
 use error::{Error, Result};
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<'w, W> ser::SerializeStruct for Struct<'w, W>
+impl<'w, W> SerializeStruct for Struct<'w, W>
 where
     W: 'w + Write,
 {
@@ -99,5 +99,26 @@ where
 
     fn end(self) -> Result<Self::Ok> {
         write!(self.parent.writer, "</{}>", self.name).map_err(|e| e.into())
+    }
+}
+
+
+impl<'w, W> SerializeStructVariant for Struct<'w, W>
+where
+    W: 'w + Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<()> {
+        <Self as SerializeStruct>::serialize_field(self, key, value)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        <Self as SerializeStruct>::end(self)
     }
 }


### PR DESCRIPTION
This is the beginning of sequence serializing. I'm still not sure how we deal with the case when someone wants to serialize `vec![1, 2, 3, 4]` though...