### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "xml-rs based deserializer for Serde (compatible with 0.9+)"
 license = "MIT"
 name = "serde-xml-rs"
 repository = "https://github.com/RReverser/serde-xml-rs"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 log = "0.3.6"


### PR DESCRIPTION
There have been some important changes to the library since 0.2.1, especially in #20 where support for floats and bools was added. I'd like to propose bumping the version and publishing 0.2.2 to crates.io.