### PR TITLE
Bump xml-rs version from 0.6 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.2.1"
 [dependencies]
 log = "0.3.6"
 serde = "1.0"
-xml-rs = "0.6.0"
+xml-rs = "0.8.0"
 error-chain = "0.10.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This simply bumps the version of xml-rs, leaving no other code changes. Tests pass just fine with no warnings, and no issues are detected!

Regarding version bump of serde-xml-rs itself, I am unsure whether this is a minor or patch? From what I briefly see, the only publicly exported parts of xml-rs are the following, which I don't know if have changed.

```rust
// lib.rs
pub use xml::reader::{EventReader, ParserConfig};

// error.rs
error_chain! {
    ...
    foreign_links {
        ...
        Syntax(::xml::reader::Error);
    }
    ...
}
```