### PR TITLE
Update README.md: Fix code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ If you have an input of the form `<foo abc="xyz">bar</foo>`, and you want to get
 
 ```rust
 struct Foo {
-  pub abc String,
-  #[serde(rename = "$value")]
-  pub body String,
+    pub abc: String,
+    #[serde(rename = "$value")]
+    pub body: String,
 }
 ```
 


### PR DESCRIPTION
Fix the code sample in the 'Parsing the "value" of a tag' section to put `:` between identifiers and types, and indent with 4 spaces (same as the other examples).