### PR TITLE
Allow untrimmed whitespace in values

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -103,6 +103,7 @@ impl<'de, R: Read> Deserializer<R> {
             match self.reader.next().map_err(ErrorKind::Syntax)? {
                 XmlEvent::StartDocument { .. } |
                 XmlEvent::ProcessingInstruction { .. } |
+                XmlEvent::Whitespace { .. } |
                 XmlEvent::Comment(_) => { /* skip */ },
                 other => return Ok(other),
             }


### PR DESCRIPTION
Currently, if you pass a config that doesn't trim whitespace, derived deserialization breaks. It is therefore impossible to serialize strings in which whitespace prefixes or suffixes are significant.

This is a one-line fix.