### PR TITLE
Support 'nil' attribute for Option<T> deserialization

### DIFF
--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -424,6 +424,7 @@ fn test_option() {
         ("<a></a>", Some("".to_string())),
         ("<a> </a>", Some("".to_string())),
         ("<a>42</a>", Some("42".to_string())),
+        ("<a nil=\"true\" />", None),
     ]);
 }
 


### PR DESCRIPTION
In cases where a null-value is represented by the `nil="true"` element
being set on a starting tag, the value should be correctly
deserialized to an `Option::None`.

See https://www.w3.org/TR/xmlschema-1/#xsi_nil

This fixes #73.

-------

Note that the implementation adds the extra `is_none` assignment to avoid ownership issues in the pattern match. I experimented with some alternative constructs that are close to the conciseness of the previous version, but they added syntactical overhead that I don't think is useful to keep.

Tested on `rustc 1.30.1`, did not check for compatibility with older versions.