### PR TITLE
Readme tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ matrix:
   fast_finish: true
   allow_failures:
     - rust: nightly
+before_script:
+  - sh ci/skeptic.sh

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ xml-rs based deserializer for Serde (compatible with 0.9+)
 
 ## Usage
 
-Use `serde_xml_rs::deserialize(...)` on any type that implements [`std::io::Read`](https://doc.rust-lang.org/std/io/trait.Read.html) as following:
+Use `serde_xml_rs::from_reader(...)` on any type that implements [`std::io::Read`](https://doc.rust-lang.org/std/io/trait.Read.html) as following:
 
 ```rust
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
 extern crate serde_xml_rs;
 
-use serde_xml_rs::deserialize;
+use serde_xml_rs::from_reader;
 
 #[derive(Debug, Deserialize)]
 struct Item {
@@ -28,14 +30,13 @@ struct Project {
     pub items: Vec<Item>
 }
 
-#[test]
-fn it_works() {
+fn main() {
     let s = r##"
         <Project name="my_project">
             <Item name="hello" source="world.rs" />
         </Project>
     "##;
-    let project: Project = deserialize(s.as_bytes()).unwrap();
+    let project: Project = from_reader(s.as_bytes()).unwrap();
     println!("{:#?}", project);
 }
 ```
@@ -46,7 +47,7 @@ Alternatively, you can use `serde_xml_rs::Deserializer` to create a deserializer
 
 If you have an input of the form `<foo abc="xyz">bar</foo>`, and you want to get at the`bar`, you can use the special name `$value`:
 
-```rust
+```rust,ignore
 struct Foo {
     pub abc: String,
     #[serde(rename = "$value")]

--- a/ci/skeptic.sh
+++ b/ci/skeptic.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+sed -i  '/\[dev-dependencies\]/a skeptic = "0.13"' Cargo.toml
+
+echo "[build-dependencies]
+skeptic = \"0.13\"" >> Cargo.toml
+
+cat <<EOT >> build.rs
+extern crate skeptic;
+
+fn main() {
+    // generates doc tests for `README.md`.
+    skeptic::generate_doc_tests(&["README.md"]);
+}
+EOT
+
+echo 'include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));' > tests/skeptic.rs


### PR DESCRIPTION
[skeptic](https://github.com/budziq/rust-skeptic) add unnecessary build time dependencies, so I add only CI test which check  that code in README.md is valid.