### PR TITLE
feature toggle backtrace in error-chain for legacy os

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,15 @@ version = "0.3.0"
 log = "0.4"
 serde = "1.0"
 xml-rs = "0.8.0"
-error-chain = "0.10.0"
+error-chain = { version = "0.10.0", optional = true }
+error-chain-no-backtrace = {version = "0.10.0", default-features = false, optional = true, package = "error-chain" }
 
 [dev-dependencies]
 serde_derive = "1.0"
 simple_logger = "1.0.1"
 docmatic = "0.1.2"
+
+[features]
+default = ["with-backtrace"]
+with-backtrace = ["error-chain"]
+legacy-support = ["error-chain-no-backtrace"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,12 @@
 //! }
 //! ```
 
-
+#[cfg(feature = "default")]
 #[macro_use]
 extern crate error_chain;
+#[cfg(feature = "legacy-support")]
+#[macro_use]
+extern crate error_chain_no_backtrace as error_chain;
 #[macro_use]
 extern crate log;
 #[macro_use]
@@ -50,7 +53,7 @@ mod error;
 pub mod de;
 pub mod ser;
 
-pub use error::{Error, ErrorKind};
-pub use xml::reader::{EventReader, ParserConfig};
-pub use ser::{to_string, to_writer, Serializer};
 pub use de::{from_reader, from_str, Deserializer};
+pub use error::{Error, ErrorKind};
+pub use ser::{to_string, to_writer, Serializer};
+pub use xml::reader::{EventReader, ParserConfig};


### PR DESCRIPTION
`error-chain` conditionally uses `backtrace` under the hood which requires a call to `SymFromAddrW`. This is part of `DbgHelp.dll` which is not supported on older operating systems such as XP or Server 2003. Currently, using `serde-xml-rs` causes an executable to crash at start because of this missing symbol. This PR introduces a way to feature flag `backtrace` off in `error-chain` without changing anything else in the library. I've tested this against Windows 10 and Server 2003 using the examples and it all seems to be functioning as intended.

`Cargo.toml` usage:
```
serde_xml_rs = { version = "*", default-features = false, features = ["legacy-support"] }
```
