### PR TITLE
Make backtrace crate optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,13 @@ version = "0.3.0"
 log = "0.4"
 serde = "1.0"
 xml-rs = "0.8.0"
-error-chain = "0.10.0"
+error-chain = { version = "0.12.0", default-features = false }
 
 [dev-dependencies]
 serde_derive = "1.0"
 simple_logger = "1.0.1"
 docmatic = "0.1.2"
+
+[features]
+default = []
+backtrace = ["error-chain/backtrace"]


### PR DESCRIPTION
I faced an issue where a recent change to the backtrace crate caused builds to fail on Android. This crate was the only crate that has it as a nested dependency in my codebase, so it would be nice if it could be either opt-in or opt-out.