### PR TITLE
Bump to version 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "xml-rs based deserializer for Serde (compatible with 0.9+)"
 license = "MIT"
 name = "serde-xml-rs"
 repository = "https://github.com/RReverser/serde-xml-rs"
-version = "0.3.0"
+version = "0.3.2"
 
 [dependencies]
 log = "0.4"


### PR DESCRIPTION
The error-chain version was increased in commit 3c5949b7aef0c65ab491859d52e504513746785c, and a new version has not been published, but also, it appears that a version `0.3.1` was published, but there is no commit for that version, which confuses cargo's `patch` mechanism.