### PR TITLE
Parse bool value in attributes

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -114,7 +114,7 @@ impl<'de> de::Deserializer<'de> for AttrValueDeserializer {
     fn deserialize_bool<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
         match self.0.as_str() {
             "true" | "1" => visitor.visit_bool(true),
-            "" | "false" | "0" => visitor.visit_bool(false),
+            "false" | "0" => visitor.visit_bool(false),
             _ => Err(de::Error::invalid_value(Unexpected::Str(&self.0), &"a boolean")),
         }
     }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-use serde::de::{self, IntoDeserializer};
+use serde::de::{self, IntoDeserializer, Unexpected};
 use xml::attribute::OwnedAttribute;
 use xml::reader::XmlEvent;
 
@@ -112,7 +112,11 @@ impl<'de> de::Deserializer<'de> for AttrValueDeserializer {
     }
 
     fn deserialize_bool<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visitor.visit_bool(!self.0.is_empty())
+        match self.0.as_str() {
+            "true" | "1" => visitor.visit_bool(true),
+            "" | "false" | "0" => visitor.visit_bool(false),
+            _ => Err(de::Error::invalid_value(Unexpected::Str(&self.0), &"a boolean")),
+        }
     }
 
     forward_to_deserialize_any! {

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -329,7 +329,7 @@ fn test_parse_u64() {
 }
 
 #[test]
-fn test_parse_bool() {
+fn test_parse_bool_element() {
     let _ = simple_logger::init();
     test_parse_ok(&[
         ("<bla>true</bla>", true),
@@ -341,6 +341,31 @@ fn test_parse_bool() {
     ]);
 
     test_parse_invalid::<bool>(&["<bla>verum</bla>"]);
+}
+
+#[test]
+fn test_parse_bool_attribute() {
+
+    #[derive(PartialEq, Debug, Deserialize, Serialize)]
+    struct Dummy {
+        foo: bool
+    }
+
+    let _ = simple_logger::init();
+    test_parse_ok(&[
+        ("<bla foo=\"true\"/>", Dummy{foo: true}),
+        ("<bla foo=\"false\"/>", Dummy{foo: false}),
+        ("<bla foo=\"1\"/>", Dummy{foo: true}),
+        ("<bla foo=\"0\"/>", Dummy{foo: false}),
+    ]);
+
+    test_parse_invalid::<Dummy>(&[
+        "<bla foo=\"bar\"/>",
+        "<bla foo=\" true \"/>",
+        "<bla foo=\"10\"/>",
+        "<bla foo=\"\"/>",
+        "<bla/>",
+    ]);
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -138,7 +138,7 @@ fn collection_of_enums() {
     let s = r##"
         <enums>
             <A>test</A>
-            <B name="hello" flag="t" />
+            <B name="hello" flag="true" />
             <C />
         </enums>
     "##;


### PR DESCRIPTION
Correctly parse true/false or 0/1 value for booleans used as attribute (previously only available for elements).

I added "" as a false value to partially match the previous behavior but I am not sure it actually makes sense. We may consider removing it.