### PR TITLE
Minor changes: Test cleanup

### DIFF
--- a/tests/failures.rs
+++ b/tests/failures.rs
@@ -15,7 +15,7 @@ struct Item {
 }
 
 #[test]
-fn simple_struct_from_attributes_should_fail() {
+fn unclosed_attributes_should_fail() {
     let _ = simple_logger::init();
 
     let s = r##"
@@ -26,7 +26,7 @@ fn simple_struct_from_attributes_should_fail() {
     match item {
         Ok(_) => assert!(false),
         Err(e) => {
-            info!("simple_struct_from_attributes_should_fail(): {}", e);
+            info!("unclosed_attributes_should_fail(): {}", e);
             assert!(true)
         }
     }

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -353,17 +353,17 @@ fn test_parse_bool_attribute() {
 
     let _ = simple_logger::init();
     test_parse_ok(&[
-        ("<bla foo=\"true\"/>", Dummy{foo: true}),
-        ("<bla foo=\"false\"/>", Dummy{foo: false}),
-        ("<bla foo=\"1\"/>", Dummy{foo: true}),
-        ("<bla foo=\"0\"/>", Dummy{foo: false}),
+        ("<bla foo='true'/>", Dummy{foo: true}),
+        ("<bla foo='false'/>", Dummy{foo: false}),
+        ("<bla foo='1'/>", Dummy{foo: true}),
+        ("<bla foo='0'/>", Dummy{foo: false}),
     ]);
 
     test_parse_invalid::<Dummy>(&[
-        "<bla foo=\"bar\"/>",
-        "<bla foo=\" true \"/>",
-        "<bla foo=\"10\"/>",
-        "<bla foo=\"\"/>",
+        "<bla foo='bar'/>",
+        "<bla foo=' true '/>",
+        "<bla foo='10'/>",
+        "<bla foo=''/>",
         "<bla/>",
     ]);
 }
@@ -421,7 +421,7 @@ fn test_parse_struct() {
             },
         ),
         (
-            "<Simple d=\"Foo\"><!-- this is a comment -->
+            "<Simple d='Foo'><!-- this is a comment -->
                 <c>abc</c>
                 <a/>
                 <b>2</b>
@@ -650,8 +650,8 @@ fn test_hugo_duncan2() {
 fn test_hugo_duncan() {
     let _ = simple_logger::init();
     let s = "
-        <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-        <DescribeInstancesResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">
+        <?xml version='1.0' encoding='UTF-8'?>
+        <DescribeInstancesResponse xmlns='http://ec2.amazonaws.com/doc/2014-10-01/'>
             <requestId>9474f558-10a5-42e8-84d1-f9ee181fe943</requestId>
             <reservationSet/>
         </DescribeInstancesResponse>

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -620,7 +620,7 @@ fn test_hugo_duncan2() {
             struct Helper<U> {
                 item: Vec<U>,
             }
-            let h: Helper<_> = try!(de::Deserialize::deserialize(deserializer));
+            let h: Helper<_> = de::Deserialize::deserialize(deserializer)?;
             Ok(ItemVec(h.item))
         }
     }


### PR DESCRIPTION
I noticed 3 things to be cleaned up when looking at the tests:

1. A test name didn't explain why it was meant to fail
2. Attribute quotes were being unnecessarily escaped
3. Deprecated syntax was being used and was raising a warning

Each of the 3 points is a separate commit and has more information inside the commit.