### PR TITLE
Switch from error-chain to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,9 @@ version = "0.3.0"
 log = "0.4"
 serde = "1.0"
 xml-rs = "0.8.0"
-error-chain = { version = "0.12", default-features = false }
+thiserror = "1.0"
 
 [dev-dependencies]
 serde_derive = "1.0"
 simple_logger = "1.0.1"
 docmatic = "0.1.2"
-
-[features]
-default = ["with-backtrace"]
-with-backtrace = ["error-chain/default"]
-legacy-support = ["error-chain/example_generated"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "xml-rs based deserializer for Serde (compatible with 0.9+)"
 license = "MIT"
 name = "serde-xml-rs"
 repository = "https://github.com/RReverser/serde-xml-rs"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 log = "0.4"

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,13 +1,13 @@
 use std::io::Read;
 
 use serde::de::{self, Unexpected};
-use xml::reader::{EventReader, ParserConfig, XmlEvent};
 use xml::name::OwnedName;
+use xml::reader::{EventReader, ParserConfig, XmlEvent};
 
-use error::{Error, ErrorKind, Result};
 use self::map::MapAccess;
 use self::seq::SeqAccess;
 use self::var::EnumAccess;
+use error::{Error, Result};
 
 mod map;
 mod seq;
@@ -35,7 +35,6 @@ mod var;
 pub fn from_str<'de, T: de::Deserialize<'de>>(s: &str) -> Result<T> {
     from_reader(s.as_bytes())
 }
-
 
 /// A convenience method for deserialize some object from a reader.
 ///
@@ -100,10 +99,10 @@ impl<'de, R: Read> Deserializer<R> {
 
     fn inner_next(&mut self) -> Result<XmlEvent> {
         loop {
-            match self.reader.next().map_err(ErrorKind::Syntax)? {
-                XmlEvent::StartDocument { .. } |
-                XmlEvent::ProcessingInstruction { .. } |
-                XmlEvent::Comment(_) => { /* skip */ },
+            match self.reader.next()? {
+                XmlEvent::StartDocument { .. }
+                | XmlEvent::ProcessingInstruction { .. }
+                | XmlEvent::Comment(_) => { /* skip */ }
                 other => return Ok(other),
             }
         }
@@ -118,11 +117,11 @@ impl<'de, R: Read> Deserializer<R> {
         match next {
             XmlEvent::StartElement { .. } => {
                 self.depth += 1;
-            },
+            }
             XmlEvent::EndElement { .. } => {
                 self.depth -= 1;
-            },
-            _ => {},
+            }
+            _ => {}
         }
         debug!("Fetched {:?}", next);
         Ok(next)
@@ -156,11 +155,11 @@ impl<'de, R: Read> Deserializer<R> {
             if name == start_name {
                 Ok(())
             } else {
-                Err(ErrorKind::Custom(format!(
+                Err(Error::Custom { field: format!(
                     "End tag </{}> didn't match the start tag <{}>",
                     name.local_name,
                     start_name.local_name
-                )).into())
+                ) })
             }
         })
     }
@@ -171,9 +170,10 @@ impl<'de, R: Read> Deserializer<R> {
         }
         self.read_inner_value::<V, String, _>(|this| {
             if let XmlEvent::EndElement { .. } = *this.peek()? {
-                return Err(
-                    ErrorKind::UnexpectedToken("EndElement".into(), "Characters".into()).into(),
-                );
+                return Err(Error::UnexpectedToken {
+                    token: "EndElement".into(),
+                    found: "Characters".into(),
+                });
             }
 
             expect!(this.next()?, XmlEvent::Characters(s) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,47 +1,64 @@
-use std::fmt::Display;
 use serde::de::Error as DeError;
 use serde::ser::Error as SerError;
+use std::fmt::Display;
+use thiserror::Error;
 
-error_chain! {
-    types {
-        Error,
-        ErrorKind,
-        ResultExt,
-        Result;
-    }
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Expected token {token}, found {found}")]
+    UnexpectedToken { token: String, found: String },
+    #[error("custom: {field}")]
+    Custom { field: String },
+    #[error("unsupported operation: '{operation}'")]
+    UnsupportedOperation { operation: String },
 
-    foreign_links {
-        Io(::std::io::Error);
-        FromUtf8Error(::std::string::FromUtf8Error);
-        ParseIntError(::std::num::ParseIntError);
-        ParseFloatError(::std::num::ParseFloatError);
-        ParseBoolError(::std::str::ParseBoolError);
-        Syntax(::xml::reader::Error);
-    }
+    #[error("IO error: {source}")]
+    Io {
+        #[from]
+        source: ::std::io::Error,
+    },
 
-    errors {
-        UnexpectedToken(token: String, found: String) {
-            description("unexpected token")
-            display("Expected token {}, found {}", token, found)
-        }
-        Custom(field: String) {
-            description("other error")
-            display("custom: '{}'", field)
-        }
-        UnsupportedOperation(operation: String) {
-            description("unsupported operation")
-            display("unsupported operation: '{}'", operation)
-        }
-    }
+    #[error("FromUtf8Error: {source}")]
+    FromUtf8Error {
+        #[from]
+        source: ::std::string::FromUtf8Error,
+    },
+
+    #[error("ParseIntError: {source}")]
+    ParseIntError {
+        #[from]
+        source: ::std::num::ParseIntError,
+    },
+
+    #[error("ParseFloatError: {source}")]
+    ParseFloatError {
+        #[from]
+        source: ::std::num::ParseFloatError,
+    },
+
+    #[error("ParseBoolError: {source}")]
+    ParseBoolError {
+        #[from]
+        source: ::std::str::ParseBoolError,
+    },
+
+    #[error("Syntax: {source}")]
+    Syntax {
+        #[from]
+        source: ::xml::reader::Error,
+    },
 }
+
+pub type Result<T> = std::result::Result<T, Error>;
 
 macro_rules! expect {
     ($actual: expr, $($expected: pat)|+ => $if_ok: expr) => {
         match $actual {
             $($expected)|+ => $if_ok,
-            actual => Err($crate::ErrorKind::UnexpectedToken(
-                stringify!($($expected)|+).to_string(), format!("{:?}",actual)
-            ).into()) as Result<_>
+            actual => Err($crate::Error::UnexpectedToken {
+                token: stringify!($($expected)|+).to_string(),
+                found: format!("{:?}",actual)
+            }) as Result<_>
         }
     }
 }
@@ -72,12 +89,16 @@ macro_rules! debug_expect {
 
 impl DeError for Error {
     fn custom<T: Display>(msg: T) -> Self {
-        ErrorKind::Custom(msg.to_string()).into()
+        Error::Custom {
+            field: msg.to_string(),
+        }
     }
 }
 
 impl SerError for Error {
     fn custom<T: Display>(msg: T) -> Self {
-        ErrorKind::Custom(msg.to_string()).into()
+        Error::Custom {
+            field: msg.to_string(),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,13 @@
 //! }
 //! ```
 
-
-#[macro_use]
-extern crate error_chain;
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde;
 extern crate xml;
+
+extern crate thiserror;
 
 #[cfg(test)]
 #[macro_use]
@@ -50,7 +49,7 @@ mod error;
 pub mod de;
 pub mod ser;
 
-pub use error::{Error, ErrorKind};
-pub use xml::reader::{EventReader, ParserConfig};
-pub use ser::{to_string, to_writer, Serializer};
 pub use de::{from_reader, from_str, Deserializer};
+pub use error::Error;
+pub use ser::{to_string, to_writer, Serializer};
+pub use xml::reader::{EventReader, ParserConfig};

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,13 +1,12 @@
-use std::io::Write;
 use std::fmt::Display;
+use std::io::Write;
 
 use serde::ser::{self, Impossible, Serialize};
 
-use error::{Error, ErrorKind, Result};
 use self::var::{Map, Struct};
+use error::{Error, Result};
 
 mod var;
-
 
 /// A convenience method for serializing some object to a buffer.
 ///
@@ -39,7 +38,6 @@ pub fn to_writer<W: Write, S: Serialize>(writer: W, value: &S) -> Result<()> {
     let mut ser = Serializer::new(writer);
     value.serialize(&mut ser)
 }
-
 
 /// A convenience method for serializing some object to a string.
 ///
@@ -102,7 +100,6 @@ where
         Ok(())
     }
 }
-
 
 #[allow(unused_variables)]
 impl<'w, W> ser::Serializer for &'w mut Serializer<W>
@@ -181,9 +178,9 @@ where
     fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok> {
         // TODO: I imagine you'd want to use base64 here.
         // Not sure how to roundtrip effectively though...
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_bytes".to_string()).into(),
-        )
+        Err(Error::UnsupportedOperation {
+            operation: "serialize_bytes".to_string(),
+        })
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
@@ -208,9 +205,9 @@ where
         variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok> {
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_unit_variant".to_string()).into(),
-        )
+        Err(Error::UnsupportedOperation {
+            operation: "serialize_unit_variant".to_string(),
+        })
     }
 
     fn serialize_newtype_struct<T: ?Sized + Serialize>(
@@ -218,9 +215,9 @@ where
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok> {
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_newtype_struct".to_string()).into(),
-        )
+        Err(Error::UnsupportedOperation {
+            operation: "serialize_newtype_struct".to_string(),
+        })
     }
 
     fn serialize_newtype_variant<T: ?Sized + Serialize>(
@@ -235,15 +232,15 @@ where
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         // TODO: Figure out how to constrain the things written to only be composites
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_seq".to_string()).into(),
-        )
+        Err(Error::UnsupportedOperation {
+            operation: "serialize_seq".to_string(),
+        })
     }
 
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_tuple".to_string()).into(),
-        )
+        Err(Error::UnsupportedOperation {
+            operation: "serialize_tuple".to_string(),
+        })
     }
 
     fn serialize_tuple_struct(
@@ -251,9 +248,9 @@ where
         name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_tuple_struct".to_string()).into(),
-        )
+        Err(Error::UnsupportedOperation {
+            operation: "serialize_tuple_struct".to_string(),
+        })
     }
 
     fn serialize_tuple_variant(
@@ -263,9 +260,9 @@ where
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        Err(
-            ErrorKind::UnsupportedOperation("serialize_tuple_variant".to_string()).into(),
-        )
+        Err(Error::UnsupportedOperation {
+            operation: "serialize_tuple_variant".to_string(),
+        })
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
@@ -284,16 +281,17 @@ where
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        Err(ErrorKind::UnsupportedOperation("Result".to_string()).into())
+        Err(Error::UnsupportedOperation {
+            operation: "Result".to_string(),
+        })
     }
 }
-
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::Serializer as SerSerializer;
     use serde::ser::{SerializeMap, SerializeStruct};
+    use serde::Serializer as SerSerializer;
 
     #[test]
     fn test_serialize_bool() {

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -9,8 +9,8 @@ extern crate serde_xml_rs;
 
 use std::fmt::Debug;
 
-use serde_xml_rs::{from_str, Error, ErrorKind};
 use serde::{de, ser};
+use serde_xml_rs::{from_str, Error};
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 enum Animal {
@@ -63,7 +63,7 @@ where
 {
     for &s in errors {
         assert!(match from_str::<T>(s) {
-            Err(Error(ErrorKind::Syntax(_), _)) => true,
+            Err(Error::Syntax { source: _ }) => true,
             _ => false,
         });
     }
@@ -75,7 +75,7 @@ where
 {
     for &s in errors {
         assert!(match from_str::<T>(s) {
-            Err(Error(_, _)) => true,
+            Err(_) => true,
             _ => false,
         });
     }
@@ -93,14 +93,12 @@ fn test_namespaces() {
     <gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
         <gesmes:subject>Reference rates</gesmes:subject>
     </gesmes:Envelope>"#;
-    test_parse_ok(&[
-        (
-            s,
-            Envelope {
-                subject: "Reference rates".to_string(),
-            },
-        ),
-    ]);
+    test_parse_ok(&[(
+        s,
+        Envelope {
+            subject: "Reference rates".to_string(),
+        },
+    )]);
 }
 
 #[test]
@@ -168,7 +166,6 @@ fn test_doctype_fail() {
             <Envelope>
             <subject>Reference rates</subject>
             </Envelope>"#,
-
         r#"
             <?xml version="1.0" encoding="UTF-8"?>
             <Envelope>
@@ -199,16 +196,14 @@ fn test_forwarded_namespace() {
 
 
     </graphml>"#;
-    test_parse_ok(&[
-        (
-            s,
-            Graphml {
-                schema_location: "http://graphml.graphdrawing.org/xmlns
+    test_parse_ok(&[(
+        s,
+        Graphml {
+            schema_location: "http://graphml.graphdrawing.org/xmlns
         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"
-                    .to_string(),
-            },
-        ),
-    ]);
+                .to_string(),
+        },
+    )]);
 }
 
 #[test]
@@ -345,18 +340,17 @@ fn test_parse_bool_element() {
 
 #[test]
 fn test_parse_bool_attribute() {
-
     #[derive(PartialEq, Debug, Deserialize, Serialize)]
     struct Dummy {
-        foo: bool
+        foo: bool,
     }
 
     let _ = simple_logger::init();
     test_parse_ok(&[
-        ("<bla foo=\"true\"/>", Dummy{foo: true}),
-        ("<bla foo=\"false\"/>", Dummy{foo: false}),
-        ("<bla foo=\"1\"/>", Dummy{foo: true}),
-        ("<bla foo=\"0\"/>", Dummy{foo: false}),
+        ("<bla foo=\"true\"/>", Dummy { foo: true }),
+        ("<bla foo=\"false\"/>", Dummy { foo: false }),
+        ("<bla foo=\"1\"/>", Dummy { foo: true }),
+        ("<bla foo=\"0\"/>", Dummy { foo: false }),
     ]);
 
     test_parse_invalid::<Dummy>(&[
@@ -467,9 +461,8 @@ fn test_amoskvin() {
         a: String,
         b: Option<String>,
     }
-    test_parse_ok(&[
-        (
-            "
+    test_parse_ok(&[(
+        "
 <root>
 <foo>
  <a>Hello</a>
@@ -479,20 +472,19 @@ fn test_amoskvin() {
  <a>Hi</a>
 </foo>
 </root>",
-            Root {
-                foo: vec![
-                    Foo {
-                        a: "Hello".to_string(),
-                        b: Some("World".to_string()),
-                    },
-                    Foo {
-                        a: "Hi".to_string(),
-                        b: None,
-                    },
-                ],
-            },
-        ),
-    ]);
+        Root {
+            foo: vec![
+                Foo {
+                    a: "Hello".to_string(),
+                    b: Some("World".to_string()),
+                },
+                Foo {
+                    a: "Hi".to_string(),
+                    b: None,
+                },
+            ],
+        },
+    )]);
 }
 
 #[test]
@@ -545,9 +537,7 @@ fn test_nicolai86() {
                 Sender: TheSender {
                     name: "European Central Bank".to_string(),
                 },
-                Cube: OuterCube {
-                    Cube: vec![],
-                }
+                Cube: OuterCube { Cube: vec![] },
             },
         ),
         (
@@ -581,7 +571,7 @@ fn test_nicolai86() {
                             },
                         ],
                     }],
-                }
+                },
             },
         ),
     ]);
@@ -620,7 +610,7 @@ fn test_hugo_duncan2() {
             struct Helper<U> {
                 item: Vec<U>,
             }
-            let h: Helper<_> = try!(de::Deserialize::deserialize(deserializer));
+            let h: Helper<_> = de::Deserialize::deserialize(deserializer)?;
             Ok(ItemVec(h.item))
         }
     }
@@ -630,20 +620,16 @@ fn test_hugo_duncan2() {
         requestId: String,
         vpcSet: ItemVec<VpcSet>,
     }
-    test_parse_ok(&[
-        (
-            s,
-            DescribeVpcsResponse {
-                requestId: "8d521e9a-509e-4ef6-bbb7-9f1ac0d49cd1".to_string(),
-                vpcSet: ItemVec(vec![
-                    VpcSet {
-                        vpcId: "vpc-ba0d18d8".to_string(),
-                        state: "available".to_string(),
-                    },
-                ]),
-            },
-        ),
-    ]);
+    test_parse_ok(&[(
+        s,
+        DescribeVpcsResponse {
+            requestId: "8d521e9a-509e-4ef6-bbb7-9f1ac0d49cd1".to_string(),
+            vpcSet: ItemVec(vec![VpcSet {
+                vpcId: "vpc-ba0d18d8".to_string(),
+                state: "available".to_string(),
+            }]),
+        },
+    )]);
 }
 
 #[test]
@@ -662,15 +648,13 @@ fn test_hugo_duncan() {
         requestId: String,
         reservationSet: (),
     }
-    test_parse_ok(&[
-        (
-            s,
-            DescribeInstancesResponse {
-                requestId: "9474f558-10a5-42e8-84d1-f9ee181fe943".to_string(),
-                reservationSet: (),
-            },
-        ),
-    ]);
+    test_parse_ok(&[(
+        s,
+        DescribeInstancesResponse {
+            requestId: "9474f558-10a5-42e8-84d1-f9ee181fe943".to_string(),
+            reservationSet: (),
+        },
+    )]);
 }
 
 #[test]
@@ -681,14 +665,12 @@ fn test_parse_xml_value() {
         #[serde(rename = "$value")]
         myval: String,
     }
-    test_parse_ok(&[
-        (
-            "<Test>abc</Test>",
-            Test {
-                myval: "abc".to_string(),
-            },
-        ),
-    ]);
+    test_parse_ok(&[(
+        "<Test>abc</Test>",
+        Test {
+            myval: "abc".to_string(),
+        },
+    )]);
 }
 
 #[test]
@@ -747,15 +729,13 @@ fn test_parse_attributes() {
         a2: i32,
     }
 
-    test_parse_ok(&[
-        (
-            r#"<A a1="What is the answer to the ultimate question?">42</A>"#,
-            A {
-                a1: "What is the answer to the ultimate question?".to_string(),
-                a2: 42,
-            },
-        ),
-    ]);
+    test_parse_ok(&[(
+        r#"<A a1="What is the answer to the ultimate question?">42</A>"#,
+        A {
+            a1: "What is the answer to the ultimate question?".to_string(),
+            a2: 42,
+        },
+    )]);
 
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     struct B {
@@ -763,15 +743,13 @@ fn test_parse_attributes() {
         b2: i32,
     }
 
-    test_parse_ok(&[
-        (
-            r#"<B b1="What is the answer to the ultimate question?" b2="42"/>"#,
-            B {
-                b1: "What is the answer to the ultimate question?".to_string(),
-                b2: 42,
-            },
-        ),
-    ]);
+    test_parse_ok(&[(
+        r#"<B b1="What is the answer to the ultimate question?" b2="42"/>"#,
+        B {
+            b1: "What is the answer to the ultimate question?".to_string(),
+            b2: 42,
+        },
+    )]);
 
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     struct C {
@@ -813,18 +791,15 @@ fn test_parse_attributes() {
     struct D {
         d1: Option<A>,
     }
-    test_parse_ok(&[
-        (
-            r#"<D><d1 a1="What is the answer to the ultimate question?">42</d1></D>"#,
-            D {
-                d1: Some(A {
-                    a1: "What is the answer to the ultimate question?".to_string(),
-                    a2: 42,
-                }),
-            },
-        ),
-    ]);
-
+    test_parse_ok(&[(
+        r#"<D><d1 a1="What is the answer to the ultimate question?">42</d1></D>"#,
+        D {
+            d1: Some(A {
+                a1: "What is the answer to the ultimate question?".to_string(),
+                a2: 42,
+            }),
+        },
+    )]);
 }
 
 #[test]
@@ -927,7 +902,6 @@ fn test_parse_hierarchies() {
     ]);
 }
 
-
 #[test]
 fn unknown_field() {
     #[derive(Deserialize, Debug, PartialEq, Eq, Serialize)]
@@ -939,9 +913,8 @@ fn unknown_field() {
     struct Other {
         d: i32,
     }
-    test_parse_ok(&[
-        (
-            "<a>
+    test_parse_ok(&[(
+        "<a>
                <b>
                  <c>5</c>
                </b>
@@ -949,11 +922,10 @@ fn unknown_field() {
                  <d>6</d>
                </other>
             </a>",
-            A {
-                other: vec![Other { d: 6 }],
-            },
-        ),
-    ]);
+        A {
+            other: vec![Other { d: 6 }],
+        },
+    )]);
 }
 
 // #[test]
@@ -968,13 +940,11 @@ fn unknown_field() {
 
 #[test]
 fn test_parse_unfinished() {
-    test_parse_err::<Simple>(&[
-        "<Simple>
+    test_parse_err::<Simple>(&["<Simple>
             <c>abc</c>
             <a/>
             <b>2</b>
-            <d/>",
-    ]);
+            <d/>"]);
 }
 
 #[test]
@@ -1109,10 +1079,8 @@ fn newtype_struct() {
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     struct Wrapper(String);
 
-    test_parse_ok(&[
-        (
-            r###"<wrapper>Content</wrapper>"###,
-            Wrapper("Content".into())
-        ),
-    ]);
+    test_parse_ok(&[(
+        r###"<wrapper>Content</wrapper>"###,
+        Wrapper("Content".into()),
+    )]);
 }


### PR DESCRIPTION
This fixes #118 and moves to a more modern error handling library (`thiserror`). It's a backwards-incompatible change due to a different public API, but it means that the `Error` type is now `Sync` and the `ErrorKind`/`Error` distinction is no longer needed.

I haven't implemented anything around backtraces here - not quite sure what the best way to handle that is. I think it would mean including a `backtrace: std::backtrace::Backtrace` on all of the Error variants annotated with `#[from]`, perhaps behind a feature flag to allow the crate to work in environments without backtrace support.

I suspect this change will also increase the minimum supported Rust version since thiserror requires Rust 1.31.