### PR TITLE
RFC: deserialize comments

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -45,6 +45,7 @@ impl<'de, 'a, R: 'a + Read> de::MapAccess<'de> for MapAccess<'a, R> {
                     }.into_deserializer(),
                 ).map(Some),
                 XmlEvent::Characters(_) => seed.deserialize("$value".into_deserializer()).map(Some),
+                XmlEvent::Comment(_) => seed.deserialize("$comment".into_deserializer()).map(Some),
                 _ => Ok(None),
             },
         }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -81,7 +81,7 @@ impl<'de, R: Read> Deserializer<R> {
             .trim_whitespace(true)
             .whitespace_to_characters(true)
             .cdata_to_characters(true)
-            .ignore_comments(true)
+            .ignore_comments(false)
             .coalesce_characters(true);
 
         Self::new(EventReader::new_with_config(reader, config))
@@ -100,9 +100,9 @@ impl<'de, R: Read> Deserializer<R> {
     fn inner_next(&mut self) -> Result<XmlEvent> {
         loop {
             match self.reader.next()? {
-                XmlEvent::StartDocument { .. }
-                | XmlEvent::ProcessingInstruction { .. }
-                | XmlEvent::Comment(_) => { /* skip */ }
+                XmlEvent::StartDocument { .. } | XmlEvent::ProcessingInstruction { .. } => {
+                    /* skip */
+                },
                 other => return Ok(other),
             }
         }
@@ -318,7 +318,7 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
             if let XmlEvent::EndElement { .. } = *this.peek()? {
                 return visitor.visit_str("");
             }
-            expect!(this.next()?, XmlEvent::Characters(s) => {
+            expect!(this.next()?, XmlEvent::Characters(s) | XmlEvent::Comment(s) => {
                 visitor.visit_string(s)
             })
         })

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -206,6 +206,15 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
         visitor: V,
     ) -> Result<V::Value> {
         self.unset_map_value();
+        loop {
+            // FIXME: we may want to handle skipping comments in next() instead,
+            // and have a way to catch top-level comments too.
+            if let XmlEvent::Comment { .. } = *self.peek()? {
+                self.next()?;
+            } else {
+                break;
+            }
+        }
         expect!(self.next()?, XmlEvent::StartElement { name, attributes, .. } => {
             let map_value = visitor.visit_map(MapAccess::new(
                 self,

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -22,6 +22,8 @@ enum Animal {
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 struct Simple {
+    #[serde(rename = "$comment")]
+    comments: Option<String>,
     a: (),
     b: usize,
     c: String,
@@ -250,6 +252,7 @@ fn test_parse_enum() {
         (
             "<Animal xsi:type=\"Ant\"><a/><c>bla</c><b>15</b><d>Foo</d></Animal>",
             Ant(Simple {
+                comments: None,
                 a: (),
                 b: 15,
                 c: "bla".to_string(),
@@ -259,6 +262,7 @@ fn test_parse_enum() {
         (
             "<Animal xsi:type=\"Ant\"><a/><c>bla</c><b>15</b></Animal>",
             Ant(Simple {
+                comments: None,
                 a: (),
                 b: 15,
                 c: "bla".to_string(),
@@ -395,6 +399,7 @@ fn test_parse_struct() {
                 <b>2</b>
             </Simple>",
             Simple {
+                comments: None,
                 a: (),
                 b: 2,
                 c: "abc".to_string(),
@@ -403,11 +408,14 @@ fn test_parse_struct() {
         ),
         (
             "<Simple><!-- this is a comment -->
+                text
                 <c>abc</c>
+                more text
                 <a/>
                 <b>2</b>
             </Simple>",
             Simple {
+                comments: Some(" this is a comment ".to_string()),
                 a: (),
                 b: 2,
                 c: "abc".to_string(),
@@ -421,6 +429,7 @@ fn test_parse_struct() {
                 <b>2</b>
             </Simple>",
             Simple {
+                comments: Some(" this is a comment ".to_string()),
                 a: (),
                 b: 2,
                 c: "abc".to_string(),

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -393,7 +393,8 @@ fn test_parse_struct() {
 
     test_parse_ok(&[
         (
-            "<Simple>
+            "<!-- ignore me -->
+            <Simple>
                 <c>abc</c>
                 <a/>
                 <b>2</b>


### PR DESCRIPTION
Introduce the "$comment" variable to deserialize XML comments.

TODO: support for Vec is currently not working (it seems to swallow the
remaining elements/attributes).

TODO: serialize side (it's only faire since $value doesn't support it
either atm)