### PR TITLE
Support seq and maps (refactor of #129)

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use serde::ser::{self, Impossible, Serialize};
 
-use self::var::{Map, Struct, Seq};
+use self::var::{Map, Seq, Struct};
 use error::{Error, Result};
 
 mod var;
@@ -85,7 +85,7 @@ where
     W: Write,
 {
     pub fn new(writer: W) -> Self {
-        Self { writer: writer }
+        Self { writer }
     }
 
     fn write_primitive<P: Display>(&mut self, primitive: P) -> Result<()> {
@@ -229,7 +229,6 @@ where
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        write!(self.writer, "<list>")?;
         Ok(Self::SerializeSeq::new(self))
     }
 
@@ -262,7 +261,6 @@ where
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
-        write!(self.writer, "<map>")?;
         Ok(Map::new(self))
     }
 
@@ -288,6 +286,7 @@ where
 mod tests {
     use super::*;
     use serde::ser::{SerializeMap, SerializeStruct};
+    use serde::Serialize;
     use serde::Serializer as SerSerializer;
 
     #[test]
@@ -361,14 +360,41 @@ mod tests {
     #[test]
     fn test_serialize_simple_map() {
         let mut hashmap = std::collections::HashMap::new();
-        let mut buffer = Vec::new();
         hashmap.insert("key1", "val1");
+        let mut buffer = Vec::new();
         {
             let mut ser = Serializer::new(&mut buffer);
-            hashmap.serialize(&mut ser).expect("unable to serialize a hashmap instance");
+            hashmap
+                .serialize(&mut ser)
+                .expect("unable to serialize a hashmap instance");
         }
         let got = String::from_utf8(buffer).unwrap();
-        assert_eq!("<map><key1>val1</key1></map>", got)
+        assert_eq!("<key1>val1</key1>", got)
+    }
+
+    #[test]
+    fn test_serialize_map_within_struct() {
+        #[derive(Serialize)]
+        struct Thing {
+            things: std::collections::HashMap<String, String>,
+        }
+
+        let mut hashmap = std::collections::HashMap::new();
+        hashmap.insert("key1".to_string(), "val1".to_string());
+        hashmap.insert("key2".to_string(), "val2".to_string());
+        let sut = Thing { things: hashmap };
+
+        let mut buffer = Vec::new();
+        {
+            let mut ser = Serializer::new(&mut buffer);
+            sut.serialize(&mut ser)
+                .expect("unable to serialize a struct with a hashmap");
+        }
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!(
+            "<Thing><things><key1>val1</key1><key2>val2</key2></things></Thing>",
+            got
+        )
     }
 
     #[test]
@@ -411,19 +437,70 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn serialize_a_list() {
-        let inputs = vec![1, 2, 3, 4];
-
+    fn test_serialize_vector() {
+        let vector = vec![1, 2, 3];
         let mut buffer = Vec::new();
-
         {
             let mut ser = Serializer::new(&mut buffer);
-            inputs.serialize(&mut ser).unwrap();
+            vector.serialize(&mut ser).unwrap();
+        }
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!("123", got);
+    }
+
+    #[test]
+    fn test_serialize_vector_of_primitives_within_struct() {
+        #[derive(Serialize)]
+        struct Thing {
+            things: Vec<String>,
+        }
+
+        let sut = Thing {
+            things: vec!["thing_1".to_string(), "thing two".to_string()],
+        };
+
+        let mut buffer = Vec::new();
+        {
+            let mut ser = Serializer::new(&mut buffer);
+            sut.serialize(&mut ser).unwrap();
         }
 
         let got = String::from_utf8(buffer).unwrap();
-        println!("{}", got);
-        panic!();
+        assert_eq!("<Thing><things>thing_1thing two</things></Thing>", got);
+    }
+
+    #[test]
+    fn test_serialize_vector_of_structs_within_struct() {
+        #[derive(Serialize)]
+        #[serde(rename = "thing")]
+        struct Thing {
+            things: Vec<SubThing>,
+        }
+
+        #[derive(Serialize)]
+        #[serde(rename = "sub_thing")]
+        struct SubThing {
+            message: String,
+        }
+
+        let sut = Thing {
+            things: vec![
+                SubThing {
+                    message: "stuff".to_string(),
+                },
+                SubThing {
+                    message: "more stuff".to_string(),
+                },
+            ],
+        };
+
+        let mut buffer = Vec::new();
+        {
+            let mut ser = Serializer::new(&mut buffer);
+            sut.serialize(&mut ser).unwrap();
+        }
+
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!("<thing><things><sub_thing><message>stuff</message></sub_thing><sub_thing><message>more stuff</message></sub_thing></things></thing>", got);
     }
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use serde::ser::{self, Impossible, Serialize};
 
-use self::var::{Map, Struct};
+use self::var::{Map, Struct, Seq};
 use error::{Error, Result};
 
 mod var;
@@ -109,7 +109,7 @@ where
     type Ok = ();
     type Error = Error;
 
-    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeSeq = Seq<'w, W>;
     type SerializeTuple = Impossible<Self::Ok, Self::Error>;
     type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
     type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
@@ -205,9 +205,7 @@ where
         variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok> {
-        Err(Error::UnsupportedOperation {
-            operation: "serialize_unit_variant".to_string(),
-        })
+        self.serialize_none()
     }
 
     fn serialize_newtype_struct<T: ?Sized + Serialize>(
@@ -231,10 +229,8 @@ where
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        // TODO: Figure out how to constrain the things written to only be composites
-        Err(Error::UnsupportedOperation {
-            operation: "serialize_seq".to_string(),
-        })
+        write!(self.writer, "<list>")?;
+        Ok(Self::SerializeSeq::new(self))
     }
 
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
@@ -266,6 +262,7 @@ where
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
+        write!(self.writer, "<map>")?;
         Ok(Map::new(self))
     }
 
@@ -359,6 +356,19 @@ mod tests {
 
         let got = String::from_utf8(buffer).unwrap();
         assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn test_serialize_simple_map() {
+        let mut hashmap = std::collections::HashMap::new();
+        let mut buffer = Vec::new();
+        hashmap.insert("key1", "val1");
+        {
+            let mut ser = Serializer::new(&mut buffer);
+            hashmap.serialize(&mut ser).expect("unable to serialize a hashmap instance");
+        }
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!("<map><key1>val1</key1></map>", got)
     }
 
     #[test]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -451,12 +451,12 @@ mod tests {
     #[test]
     fn test_serialize_vector_of_primitives_within_struct() {
         #[derive(Serialize)]
-        struct Thing {
-            things: Vec<String>,
+        struct Team {
+            projects: Vec<String>,
         }
 
-        let sut = Thing {
-            things: vec!["thing_1".to_string(), "thing two".to_string()],
+        let sut = Team {
+            projects: vec!["thing_1".to_string(), "thing two".to_string()],
         };
 
         let mut buffer = Vec::new();
@@ -466,30 +466,30 @@ mod tests {
         }
 
         let got = String::from_utf8(buffer).unwrap();
-        assert_eq!("<Thing><things>thing_1thing two</things></Thing>", got);
+        assert_eq!("<Team><projects>thing_1thing two</projects></Team>", got);
     }
 
     #[test]
     fn test_serialize_vector_of_structs_within_struct() {
         #[derive(Serialize)]
-        #[serde(rename = "thing")]
-        struct Thing {
-            things: Vec<SubThing>,
+        #[serde(rename = "team")]
+        struct Team {
+            people: Vec<Person>,
         }
 
         #[derive(Serialize)]
-        #[serde(rename = "sub_thing")]
-        struct SubThing {
-            message: String,
+        #[serde(rename = "person")]
+        struct Person {
+            name: String,
         }
 
-        let sut = Thing {
-            things: vec![
-                SubThing {
-                    message: "stuff".to_string(),
+        let sut = Team {
+            people: vec![
+                Person {
+                    name: "Joe".to_string(),
                 },
-                SubThing {
-                    message: "more stuff".to_string(),
+                Person {
+                    name: "Jane".to_string(),
                 },
             ],
         };
@@ -501,6 +501,6 @@ mod tests {
         }
 
         let got = String::from_utf8(buffer).unwrap();
-        assert_eq!("<thing><things><sub_thing><message>stuff</message></sub_thing><sub_thing><message>more stuff</message></sub_thing></things></thing>", got);
+        assert_eq!("<team><people><person><name>Joe</name></person><person><name>Jane</name></person></people></team>", got);
     }
 }

--- a/src/ser/var.rs
+++ b/src/ser/var.rs
@@ -2,8 +2,8 @@ use std::io::Write;
 
 use serde::ser::{self, Serialize};
 
-use ser::Serializer;
 use error::{Error, Result};
+use ser::Serializer;
 
 /// An implementation of `SerializeMap` for serializing to XML.
 pub struct Map<'w, W>
@@ -62,7 +62,6 @@ where
     }
 
     fn end(self) -> Result<Self::Ok> {
-        write!(self.parent.writer, "</map>")?;
         Ok(())
     }
 }
@@ -110,36 +109,35 @@ where
 
 /// An implementation of `SerializeSequence` for serializing to XML.
 pub struct Seq<'w, W>
-    where
-        W: 'w + Write,
+where
+    W: 'w + Write,
 {
     parent: &'w mut Serializer<W>,
 }
 
 impl<'w, W> ser::SerializeSeq for Seq<'w, W>
-    where
-        W: 'w + Write,
+where
+    W: 'w + Write,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()> where
-        T: Serialize {
-        write!(self.parent.writer, "<item>")?;
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    where
+        T: Serialize,
+    {
         value.serialize(&mut *self.parent)?;
-        write!(self.parent.writer, "</item>")?;
         Ok(())
     }
 
     fn end(self) -> Result<Self::Ok> {
-        write!(self.parent.writer, "</list>")?;
         Ok(())
     }
 }
 
 impl<'w, W> Seq<'w, W>
-    where
-        W: 'w + Write,
+where
+    W: 'w + Write,
 {
     pub fn new(parent: &'w mut Serializer<W>) -> Seq<'w, W> {
         Self { parent }

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -2,16 +2,17 @@
 extern crate serde_derive;
 extern crate serde;
 extern crate serde_xml_rs;
+extern crate xml;
 
 use serde::Deserialize;
-use serde_xml_rs::{from_str, to_string, EventReader, ParserConfig};
+use serde_xml_rs::{from_str, to_string};
+use serde_xml_rs::{EventReader, ParserConfig};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct Item {
     name: String,
     source: String,
 }
-
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 enum Node {
@@ -25,7 +26,6 @@ struct Nodes {
     #[serde(rename = "$value")]
     items: Vec<Node>,
 }
-
 
 #[test]
 fn basic_struct() {
@@ -41,7 +41,6 @@ fn basic_struct() {
     let reserialized_item = to_string(&item).unwrap();
     assert_eq!(src, reserialized_item);
 }
-
 
 #[test]
 #[ignore]
@@ -93,18 +92,14 @@ fn whitespace_preserving_config() {
         name: "  space banana  ".to_string(),
         source: "   fantasy costco   ".to_string(),
     };
-    let config = ParserConfig::new()
-        .trim_whitespace(false)
-        .whitespace_to_characters(false);
-    let mut deserializer =
-        serde_xml_rs::Deserializer::new(EventReader::new_with_config(src.as_bytes(), config));
+    let config = ParserConfig::new().trim_whitespace(false).whitespace_to_characters(false);
+    let mut deserializer = serde_xml_rs::Deserializer::new(EventReader::new_with_config(src.as_bytes(), config));
 
     let item = Item::deserialize(&mut deserializer).unwrap();
     assert_eq!(item, item_should_be);
 
     // Space outside values is not preserved.
-    let serialized_should_be =
-        "<Item><name>  space banana  </name><source>   fantasy costco   </source></Item>";
+    let serialized_should_be = "<Item><name>  space banana  </name><source>   fantasy costco   </source></Item>";
     let reserialized_item = to_string(&item).unwrap();
     assert_eq!(reserialized_item, serialized_should_be);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,8 +4,10 @@ extern crate serde_xml_rs;
 
 extern crate log;
 extern crate simple_logger;
+extern crate serde;
 
 use serde_xml_rs::from_str;
+use serde::Deserializer;
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Item {


### PR DESCRIPTION
Based on https://github.com/RReverser/serde-xml-rs/pull/129

This MR adds support to serialize maps and vectors. Example:

```rust
#[derive(Serialize)]
#[serde(rename = "team")]
struct Team {
    people: Vec<Person>,
}

#[derive(Serialize)]
#[serde(rename = "person")]
struct Person {
    name: String,
}
```

will get serialized as:

```xml
<team>
    <people>
        <person>
            <name>Joe</name>
        </person>
        <person>
            <name>Jane</name>
        </person>
    </people>
</team>
```

Note: the pipeline fails at the same test as the master branch (`test_doctype_fail`)