### PR TITLE
Support deserializing sequences from non-contiguous elements

### DIFF
--- a/src/de/buffer.rs
+++ b/src/de/buffer.rs
@@ -1,0 +1,160 @@
+use error::Result;
+use std::{collections::VecDeque, io::Read};
+use xml::reader::{EventReader, XmlEvent};
+
+/// Retrieve XML events from an underlying reader.
+pub trait BufferedXmlReader<R: Read> {
+    /// Get and "consume" the next event.
+    fn next(&mut self) -> Result<XmlEvent>;
+
+    /// Get the next event without consuming.
+    fn peek(&mut self) -> Result<&XmlEvent>;
+
+    /// Spawn a child buffer whose cursor starts at the same position as this buffer.
+    fn child_buffer<'a>(&'a mut self) -> ChildXmlBuffer<'a, R>;
+}
+
+pub struct RootXmlBuffer<R: Read> {
+    reader: EventReader<R>,
+    buffer: VecDeque<CachedXmlEvent>,
+}
+
+impl<R: Read> RootXmlBuffer<R> {
+    pub fn new(reader: EventReader<R>) -> Self {
+        RootXmlBuffer {
+            reader,
+            buffer: VecDeque::new(),
+        }
+    }
+}
+
+impl<R: Read> BufferedXmlReader<R> for RootXmlBuffer<R> {
+    /// Consumed XML events in the root buffer are moved to the caller
+    fn next(&mut self) -> Result<XmlEvent> {
+        loop {
+            match self.buffer.pop_front() {
+                Some(CachedXmlEvent::Unused(ev)) => break Ok(ev),
+                Some(CachedXmlEvent::Used) => continue,
+                None => break next_significant_event(&mut self.reader),
+            }
+        }
+    }
+
+    fn peek(&mut self) -> Result<&XmlEvent> {
+        get_from_buffer_or_reader(&mut self.buffer, &mut self.reader, &mut 0)
+    }
+
+    fn child_buffer<'root>(&'root mut self) -> ChildXmlBuffer<'root, R> {
+        let RootXmlBuffer { reader, buffer } = self;
+        ChildXmlBuffer {
+            reader,
+            buffer,
+            cursor: 0,
+        }
+    }
+}
+
+pub struct ChildXmlBuffer<'parent, R: Read> {
+    reader: &'parent mut EventReader<R>,
+    buffer: &'parent mut VecDeque<CachedXmlEvent>,
+    cursor: usize,
+}
+
+impl<'parent, R: Read> ChildXmlBuffer<'parent, R> {
+    /// Advance the child buffer without marking an event as "used"
+    pub fn skip(&mut self) {
+        debug_assert!(
+            self.cursor < self.buffer.len(),
+            ".skip() only should be called after .peek()"
+        );
+
+        self.cursor += 1;
+    }
+}
+
+impl<'parent, R: Read> BufferedXmlReader<R> for ChildXmlBuffer<'parent, R> {
+    /// Consumed XML events in a child buffer are marked as "used"
+    fn next(&mut self) -> Result<XmlEvent> {
+        loop {
+            match self.buffer.get_mut(self.cursor) {
+                Some(entry @ CachedXmlEvent::Unused(_)) => {
+                    let taken = std::mem::replace(entry, CachedXmlEvent::Used);
+
+                    return debug_expect!(taken, CachedXmlEvent::Unused(ev) => Ok(ev));
+                }
+                Some(CachedXmlEvent::Used) => {
+                    self.cursor += 1;
+                    continue;
+                }
+                None => {
+                    debug_assert_eq!(self.buffer.len(), self.cursor);
+
+                    // Skip creation of buffer entry when consuming event straight away
+                    return next_significant_event(&mut self.reader);
+                }
+            }
+        }
+    }
+
+    fn peek(&mut self) -> Result<&XmlEvent> {
+        get_from_buffer_or_reader(self.buffer, self.reader, &mut self.cursor)
+    }
+
+    fn child_buffer<'a>(&'a mut self) -> ChildXmlBuffer<'a, R> {
+        let ChildXmlBuffer {
+            reader,
+            buffer,
+            cursor,
+        } = self;
+
+        ChildXmlBuffer {
+            reader,
+            buffer,
+            cursor: *cursor,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CachedXmlEvent {
+    Unused(XmlEvent),
+    Used,
+}
+
+fn get_from_buffer_or_reader<'buf>(
+    buffer: &'buf mut VecDeque<CachedXmlEvent>,
+    reader: &mut EventReader<impl Read>,
+    index: &mut usize,
+) -> Result<&'buf XmlEvent> {
+    // We should only be attempting to get an event already in the buffer, or the next event to place in the buffer
+    debug_assert!(*index <= buffer.len());
+
+    loop {
+        match buffer.get_mut(*index) {
+            Some(CachedXmlEvent::Unused(_)) => break,
+            Some(CachedXmlEvent::Used) => {
+                *index += 1;
+            }
+            None => {
+                let next = next_significant_event(reader)?;
+                buffer.push_back(CachedXmlEvent::Unused(next));
+            }
+        }
+    }
+
+    // Returning of borrowed data must be done after of loop/match due to current limitation of borrow checker
+    debug_expect!(buffer.get_mut(*index), Some(CachedXmlEvent::Unused(event)) => Ok(event))
+}
+
+/// Reads the next XML event from the underlying reader, skipping events we're not interested in.
+fn next_significant_event(reader: &mut EventReader<impl Read>) -> Result<XmlEvent> {
+    loop {
+        match reader.next()? {
+            XmlEvent::StartDocument { .. }
+            | XmlEvent::ProcessingInstruction { .. }
+            | XmlEvent::Whitespace { .. }
+            | XmlEvent::Comment(_) => { /* skip */ }
+            other => return Ok(other),
+        }
+    }
+}

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -66,7 +66,7 @@ type ChildDeserializer<'parent, R> = Deserializer<R, ChildXmlBuffer<'parent, R>>
 
 pub struct Deserializer<
     R: Read, // Kept as type param to avoid type signature breaking-change
-    B: BufferedXmlReader<R>,
+    B: BufferedXmlReader<R> = RootXmlBuffer<R>,
 > {
     /// XML document nested element depth
     depth: usize,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,14 +1,16 @@
-use std::io::Read;
+use std::{io::Read, marker::PhantomData};
 
 use serde::de::{self, Unexpected};
 use xml::name::OwnedName;
 use xml::reader::{EventReader, ParserConfig, XmlEvent};
 
+use self::buffer::{BufferedXmlReader, ChildXmlBuffer, RootXmlBuffer};
 use self::map::MapAccess;
 use self::seq::SeqAccess;
 use self::var::EnumAccess;
 use error::{Error, Result};
 
+mod buffer;
 mod map;
 mod seq;
 mod var;
@@ -59,20 +61,29 @@ pub fn from_reader<'de, R: Read, T: de::Deserialize<'de>>(reader: R) -> Result<T
     T::deserialize(&mut Deserializer::new_from_reader(reader))
 }
 
-pub struct Deserializer<R: Read> {
+type RootDeserializer<R> = Deserializer<R, RootXmlBuffer<R>>;
+type ChildDeserializer<'parent, R> = Deserializer<R, ChildXmlBuffer<'parent, R>>;
+
+pub struct Deserializer<
+    R: Read, // Kept as type param to avoid type signature breaking-change
+    B: BufferedXmlReader<R>,
+> {
+    /// XML document nested element depth
     depth: usize,
-    reader: EventReader<R>,
-    peeked: Option<XmlEvent>,
+    buffered_reader: B,
     is_map_value: bool,
+    marker: PhantomData<R>,
 }
 
-impl<'de, R: Read> Deserializer<R> {
+impl<'de, R: Read> RootDeserializer<R> {
     pub fn new(reader: EventReader<R>) -> Self {
+        let buffered_reader = RootXmlBuffer::new(reader);
+
         Deserializer {
+            buffered_reader,
             depth: 0,
-            reader: reader,
-            peeked: None,
             is_map_value: false,
+            marker: PhantomData,
         }
     }
 
@@ -86,35 +97,37 @@ impl<'de, R: Read> Deserializer<R> {
 
         Self::new(EventReader::new_with_config(reader, config))
     }
+}
 
+impl<'de, R: Read, B: BufferedXmlReader<R>> Deserializer<R, B> {
+    fn child<'a>(&'a mut self) -> Deserializer<R, ChildXmlBuffer<'a, R>> {
+        let Deserializer {
+            buffered_reader,
+            depth,
+            is_map_value,
+            ..
+        } = self;
+
+        Deserializer {
+            buffered_reader: buffered_reader.child_buffer(),
+            depth: *depth,
+            is_map_value: *is_map_value,
+            marker: PhantomData,
+        }
+    }
+
+    /// Gets the next XML event without advancing the cursor.
     fn peek(&mut self) -> Result<&XmlEvent> {
-        if self.peeked.is_none() {
-            self.peeked = Some(self.inner_next()?);
-        }
-        debug_expect!(self.peeked.as_ref(), Some(peeked) => {
-            debug!("Peeked {:?}", peeked);
-            Ok(peeked)
-        })
+        let peeked = self.buffered_reader.peek()?;
+
+        debug!("Peeked {:?}", peeked);
+        Ok(peeked)
     }
 
-    fn inner_next(&mut self) -> Result<XmlEvent> {
-        loop {
-            match self.reader.next()? {
-                XmlEvent::StartDocument { .. }
-                | XmlEvent::ProcessingInstruction { .. }
-                | XmlEvent::Whitespace { .. }
-                | XmlEvent::Comment(_) => { /* skip */ }
-                other => return Ok(other),
-            }
-        }
-    }
-
+    /// Gets the XML event at the cursor and advances the cursor.
     fn next(&mut self) -> Result<XmlEvent> {
-        let next = if let Some(peeked) = self.peeked.take() {
-            peeked
-        } else {
-            self.inner_next()?
-        };
+        let next = self.buffered_reader.next()?;
+
         match next {
             XmlEvent::StartElement { .. } => {
                 self.depth += 1;
@@ -136,6 +149,10 @@ impl<'de, R: Read> Deserializer<R> {
         ::std::mem::replace(&mut self.is_map_value, false)
     }
 
+    /// If `self.is_map_value`: Performs the read operations specified by `f` on the inner content of an XML element.
+    /// `f` is expected to consume the entire inner contents of the element. The cursor will be moved to the end of the
+    /// element.
+    /// If `!self.is_map_value`: `f` will be performed without additional checks/advances for an outer XML element.
     fn read_inner_value<V: de::Visitor<'de>, T, F: FnOnce(&mut Self) -> Result<T>>(
         &mut self,
         f: F,
@@ -193,7 +210,9 @@ macro_rules! deserialize_type {
     }
 }
 
-impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
+impl<'de, 'a, R: Read, B: BufferedXmlReader<R>> de::Deserializer<'de>
+    for &'a mut Deserializer<R, B>
+{
     type Error = Error;
 
     forward_to_deserialize_any! {
@@ -299,7 +318,9 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 
     fn deserialize_tuple<V: de::Visitor<'de>>(self, len: usize, visitor: V) -> Result<V::Value> {
-        visitor.visit_seq(SeqAccess::new(self, Some(len)))
+        let child_deserializer = self.child();
+
+        visitor.visit_seq(SeqAccess::new(child_deserializer, Some(len)))
     }
 
     fn deserialize_enum<V: de::Visitor<'de>>(
@@ -326,7 +347,9 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 
     fn deserialize_seq<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visitor.visit_seq(SeqAccess::new(self, None))
+        let child_deserializer = self.child();
+
+        visitor.visit_seq(SeqAccess::new(child_deserializer, None))
     }
 
     fn deserialize_map<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -3,28 +3,35 @@ use std::io::Read;
 use serde::de;
 use xml::reader::XmlEvent;
 
-use de::Deserializer;
+use de::ChildDeserializer;
 use error::{Error, Result};
 
 pub struct SeqAccess<'a, R: 'a + Read> {
-    de: &'a mut Deserializer<R>,
+    de: ChildDeserializer<'a, R>,
     max_size: Option<usize>,
-    expected_name: Option<String>,
+    seq_type: SeqType,
+}
+
+pub enum SeqType {
+    /// Sequence is of elements with the same name.
+    ByElementName { expected_name: String },
+    /// Sequence is of all elements/text at current depth.
+    AllMembers,
 }
 
 impl<'a, R: 'a + Read> SeqAccess<'a, R> {
-    pub fn new(de: &'a mut Deserializer<R>, max_size: Option<usize>) -> Self {
-        let expected_name = if de.unset_map_value() {
+    pub fn new(mut de: ChildDeserializer<'a, R>, max_size: Option<usize>) -> Self {
+        let seq_type = if de.unset_map_value() {
             debug_expect!(de.peek(), Ok(&XmlEvent::StartElement { ref name, .. }) => {
-                Some(name.local_name.clone())
+                SeqType::ByElementName { expected_name: name.local_name.clone() }
             })
         } else {
-            None
+            SeqType::AllMembers
         };
         SeqAccess {
-            de: de,
-            max_size: max_size,
-            expected_name: expected_name,
+            de,
+            max_size,
+            seq_type,
         }
     }
 }
@@ -45,22 +52,48 @@ impl<'de, 'a, R: 'a + Read> de::SeqAccess<'de> for SeqAccess<'a, R> {
             },
             None => {},
         }
-        let more = match (self.de.peek()?, self.expected_name.as_ref()) {
-            (&XmlEvent::StartElement { ref name, .. }, Some(expected_name)) => {
-                &name.local_name == expected_name
+
+        let mut local_depth = 0;
+
+        match &self.seq_type {
+            SeqType::ByElementName { expected_name } => loop {
+                let next_element = self.de.peek()?;
+
+                match next_element {
+                    XmlEvent::StartElement { name, .. } if &name.local_name == expected_name => {
+                        self.de.set_map_value();
+                        return seed.deserialize(&mut self.de).map(Some);
+                    }
+                    XmlEvent::StartElement { .. } => {
+                        self.de.buffered_reader.skip();
+                        local_depth += 1;
+                    }
+                    XmlEvent::EndElement { .. } => {
+                        if local_depth == 0 {
+                            return Ok(None);
+                        } else {
+                            local_depth -= 1;
+                            self.de.buffered_reader.skip();
+                        }
+                    }
+                    XmlEvent::EndDocument => {
+                        return Ok(None);
+                    }
+                    _ => {
+                        self.de.buffered_reader.skip();
+                    }
+                }
             },
-            (&XmlEvent::EndElement { .. }, None) |
-            (_, Some(_)) |
-            (&XmlEvent::EndDocument { .. }, _) => false,
-            (_, None) => true,
-        };
-        if more {
-            if self.expected_name.is_some() {
-                self.de.set_map_value();
+            SeqType::AllMembers => {
+                let next_element = self.de.peek()?;
+
+                match next_element {
+                    XmlEvent::EndElement { .. } | XmlEvent::EndDocument => return Ok(None),
+                    _ => {
+                        return seed.deserialize(&mut self.de).map(Some);
+                    }
+                }
             }
-            seed.deserialize(&mut *self.de).map(Some)
-        } else {
-            Ok(None)
         }
     }
 

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -7,24 +7,26 @@ use xml::reader::XmlEvent;
 use de::Deserializer;
 use error::{Error, Result};
 
-pub struct EnumAccess<'a, R: 'a + Read> {
-    de: &'a mut Deserializer<R>,
+use super::buffer::BufferedXmlReader;
+
+pub struct EnumAccess<'a, R: 'a + Read, B: BufferedXmlReader<R>> {
+    de: &'a mut Deserializer<R, B>,
 }
 
-impl<'a, R: 'a + Read> EnumAccess<'a, R> {
-    pub fn new(de: &'a mut Deserializer<R>) -> Self {
+impl<'a, R: 'a + Read, B: BufferedXmlReader<R>> EnumAccess<'a, R, B> {
+    pub fn new(de: &'a mut Deserializer<R, B>) -> Self {
         EnumAccess { de: de }
     }
 }
 
-impl<'de, 'a, R: 'a + Read> de::EnumAccess<'de> for EnumAccess<'a, R> {
+impl<'de, 'a, R: 'a + Read, B: BufferedXmlReader<R>> de::EnumAccess<'de> for EnumAccess<'a, R, B> {
     type Error = Error;
-    type Variant = VariantAccess<'a, R>;
+    type Variant = VariantAccess<'a, R, B>;
 
     fn variant_seed<V: de::DeserializeSeed<'de>>(
         self,
         seed: V,
-    ) -> Result<(V::Value, VariantAccess<'a, R>)> {
+    ) -> Result<(V::Value, VariantAccess<'a, R, B>)> {
         let name = expect!(
             self.de.peek()?,
 
@@ -38,17 +40,19 @@ impl<'de, 'a, R: 'a + Read> de::EnumAccess<'de> for EnumAccess<'a, R> {
     }
 }
 
-pub struct VariantAccess<'a, R: 'a + Read> {
-    de: &'a mut Deserializer<R>,
+pub struct VariantAccess<'a, R: 'a + Read, B: BufferedXmlReader<R>> {
+    de: &'a mut Deserializer<R, B>,
 }
 
-impl<'a, R: 'a + Read> VariantAccess<'a, R> {
-    pub fn new(de: &'a mut Deserializer<R>) -> Self {
+impl<'a, R: 'a + Read, B: BufferedXmlReader<R>> VariantAccess<'a, R, B> {
+    pub fn new(de: &'a mut Deserializer<R, B>) -> Self {
         VariantAccess { de: de }
     }
 }
 
-impl<'de, 'a, R: 'a + Read> de::VariantAccess<'de> for VariantAccess<'a, R> {
+impl<'de, 'a, R: 'a + Read, B: BufferedXmlReader<R>> de::VariantAccess<'de>
+    for VariantAccess<'a, R, B>
+{
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -159,3 +159,177 @@ fn collection_of_enums() {
         }
     );
 }
+
+#[test]
+fn out_of_order_collection() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Collection {
+        a: Vec<A>,
+        b: Vec<B>,
+        c: C,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct A {
+        name: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct B {
+        name: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct C {
+        name: String,
+    }
+
+    let _ = simple_logger::init();
+
+    let in_xml = r#"
+        <collection>
+            <a name="a1" />
+            <a name="a2" />
+            <b name="b1" />
+            <a name="a3" />
+            <c name="c" />
+            <b name="b2" />
+            <a name="a4" />
+        </collection>
+    "#;
+
+    let should_be = Collection {
+        a: vec![
+            A { name: "a1".into() },
+            A { name: "a2".into() },
+            A { name: "a3".into() },
+            A { name: "a4".into() },
+        ],
+        b: vec![B { name: "b1".into() }, B { name: "b2".into() }],
+        c: C { name: "c".into() },
+    };
+
+    let actual: Collection = from_str(&in_xml).unwrap();
+
+    assert_eq!(should_be, actual);
+}
+
+#[test]
+fn nested_out_of_order_collection() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct OuterCollection {
+        a: A,
+        inner: Vec<InnerCollection>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct InnerCollection {
+        b: Vec<B>,
+        c: Vec<C>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct A {
+        name: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct B {
+        name: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct C {
+        name: String,
+    }
+
+    let _ = simple_logger::init();
+
+    let in_xml = r#"
+        <collection>
+            <inner>
+                <b name="b1" />
+                <c name="c1" />
+                <b name="b2" />
+                <c name="c2" />
+            </inner>
+            <a name="a" />
+            <inner>
+                <c name="c3" />
+                <b name="b3" />
+                <c name="c4" />
+                <b name="b4" />
+            </inner>
+        </collection>
+    "#;
+
+    let should_be = OuterCollection {
+        a: A { name: "a".into() },
+        inner: vec![
+            InnerCollection {
+                b: vec![B { name: "b1".into() }, B { name: "b2".into() }],
+                c: vec![C { name: "c1".into() }, C { name: "c2".into() }],
+            },
+            InnerCollection {
+                b: vec![B { name: "b3".into() }, B { name: "b4".into() }],
+                c: vec![C { name: "c3".into() }, C { name: "c4".into() }],
+            },
+        ],
+    };
+
+    let actual: OuterCollection = from_str(&in_xml).unwrap();
+
+    assert_eq!(should_be, actual);
+}
+
+#[test]
+fn out_of_order_tuple() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Collection {
+        val: (A, B, C),
+        other: A,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct A {
+        name_a: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct B {
+        name_b: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct C {
+        name_c: String,
+    }
+
+    let _ = simple_logger::init();
+
+    let in_xml = r#"
+        <collection>
+            <val name_a="a1" />
+            <val name_b="b" />
+            <other name_a="a2" />
+            <val name_c="c" />
+        </collection>
+    "#;
+
+    let should_be = Collection {
+        val: (
+            A {
+                name_a: "a1".into(),
+            },
+            B { name_b: "b".into() },
+            C { name_c: "c".into() },
+        ),
+        other: A {
+            name_a: "a2".into(),
+        },
+    };
+
+    let actual: Collection = from_str(&in_xml).unwrap();
+
+    assert_eq!(should_be, actual);
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,4 @@
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_xml_rs;
@@ -5,7 +6,8 @@ extern crate serde_xml_rs;
 extern crate log;
 extern crate simple_logger;
 
-use serde_xml_rs::from_str;
+use serde::Deserialize;
+use serde_xml_rs::{from_str, Deserializer};
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Item {
@@ -209,7 +211,8 @@ fn out_of_order_collection() {
         c: C { name: "c".into() },
     };
 
-    let actual: Collection = from_str(&in_xml).unwrap();
+    let mut de = Deserializer::new_from_reader(in_xml.as_bytes()).non_contiguous_seq_elements(true);
+    let actual = Collection::deserialize(&mut de).unwrap();
 
     assert_eq!(should_be, actual);
 }
@@ -277,7 +280,8 @@ fn nested_out_of_order_collection() {
         ],
     };
 
-    let actual: OuterCollection = from_str(&in_xml).unwrap();
+    let mut de = Deserializer::new_from_reader(in_xml.as_bytes()).non_contiguous_seq_elements(true);
+    let actual = OuterCollection::deserialize(&mut de).unwrap();
 
     assert_eq!(should_be, actual);
 }
@@ -329,7 +333,8 @@ fn out_of_order_tuple() {
         },
     };
 
-    let actual: Collection = from_str(&in_xml).unwrap();
+    let mut de = Deserializer::new_from_reader(in_xml.as_bytes()).non_contiguous_seq_elements(true);
+    let actual = Collection::deserialize(&mut de).unwrap();
 
     assert_eq!(should_be, actual);
 }
@@ -373,7 +378,8 @@ fn nested_collection_repeated_elements() {
         },
     };
 
-    let actual: OuterCollection = from_str(&in_xml).unwrap();
+    let mut de = Deserializer::new_from_reader(in_xml.as_bytes()).non_contiguous_seq_elements(true);
+    let actual = OuterCollection::deserialize(&mut de).unwrap();
 
     assert_eq!(should_be, actual);
 }


### PR DESCRIPTION
Fixes #55.

The sequence deserializer had been modified to optionally read all XML events until the end of the current depth. Unused events are kept in a buffer which is re-read by the parent deserializer.

The buffer will be trimmed when the top-level deserializer moves on to avoid excess memory usage. Events which have been consumed by sequence deserializers in the middle of the buffer are replaced with tombstones to avoid unnecessary shuffling.

Some documentation which isn't strictly relevant to this change has been added in a few modules which I found hard to follow at first.

Some considerations:

- Currently, a `Deserializer` must be constructed manually to enable this behaviour. Not sure if/how we might want to expose the option in a way compatible with the convenience functions `from_str`/`from_reader`.
- `Deserializer` type signature has an unnecessary type param `R: Read`, kept to avoid an API change. But this could be removed.
- With reading of out-of-order elements enabled, memory usage will increase. This increase is proportional to the number of non-sequence elements which come after the start of a sequence (with the same parent element).