### PR TITLE
Migrate to builder pattern for initializing SimpleLogger

### DIFF
--- a/tests/failures.rs
+++ b/tests/failures.rs
@@ -7,6 +7,11 @@ extern crate log;
 extern crate simple_logger;
 
 use serde_xml_rs::from_str;
+use simple_logger::SimpleLogger;
+
+fn init_logger() {
+    let _ = SimpleLogger::new().init();
+}
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Item {
@@ -16,7 +21,7 @@ struct Item {
 
 #[test]
 fn simple_struct_from_attributes_should_fail() {
-    let _ = simple_logger::init();
+    init_logger();
 
     let s = r##"
         <item name="hello" source="world.rs />
@@ -34,7 +39,7 @@ fn simple_struct_from_attributes_should_fail() {
 
 #[test]
 fn multiple_roots_attributes_should_fail() {
-    let _ = simple_logger::init();
+    init_logger();
 
     let s = r##"
         <item name="hello" source="world.rs" />

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -7,10 +7,15 @@ extern crate simple_logger;
 extern crate serde;
 extern crate serde_xml_rs;
 
+use simple_logger::SimpleLogger;
 use std::fmt::Debug;
 
 use serde::{de, ser};
 use serde_xml_rs::{from_str, Error};
+
+fn init_logger() {
+    let _ = SimpleLogger::new().init();
+}
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 enum Animal {
@@ -83,7 +88,7 @@ where
 
 #[test]
 fn test_namespaces() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(PartialEq, Serialize, Deserialize, Debug)]
     struct Envelope {
         subject: String,
@@ -103,7 +108,7 @@ fn test_namespaces() {
 
 #[test]
 fn test_doctype() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(PartialEq, Serialize, Deserialize, Debug)]
     struct Envelope {
         subject: String,
@@ -177,7 +182,7 @@ fn test_forwarded_namespace() {
 
 #[test]
 fn test_parse_string() {
-    let _ = simple_logger::init();
+    init_logger();
 
     test_parse_ok(&[
         (
@@ -199,7 +204,7 @@ fn test_parse_string() {
 #[test]
 #[ignore] // FIXME
 fn test_parse_string_not_trim() {
-    let _ = simple_logger::init();
+    init_logger();
 
     test_parse_ok(&[("<bla>     </bla>", "     ".to_string())]);
 }
@@ -208,7 +213,7 @@ fn test_parse_string_not_trim() {
 #[ignore] // FIXME
 fn test_parse_enum() {
     use self::Animal::*;
-    let _ = simple_logger::init();
+    init_logger();
 
     test_parse_ok(&[
         ("<Animal xsi:type=\"Dog\"/>", Dog),
@@ -273,7 +278,7 @@ fn test_parse_enum() {
 
 #[test]
 fn test_parse_i64() {
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[
         ("<bla>0</bla>", 0),
         ("<bla>-2</bla>", -2),
@@ -284,7 +289,7 @@ fn test_parse_i64() {
 
 #[test]
 fn test_parse_u64() {
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[
         ("<bla>0</bla>", 0),
         ("<bla>1234</bla>", 1234),
@@ -294,7 +299,7 @@ fn test_parse_u64() {
 
 #[test]
 fn test_parse_bool_element() {
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[
         ("<bla>true</bla>", true),
         ("<bla>false</bla>", false),
@@ -314,7 +319,7 @@ fn test_parse_bool_attribute() {
         foo: bool,
     }
 
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[
         ("<bla foo=\"true\"/>", Dummy { foo: true }),
         ("<bla foo=\"false\"/>", Dummy { foo: false }),
@@ -333,13 +338,13 @@ fn test_parse_bool_attribute() {
 
 #[test]
 fn test_parse_unit() {
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[("<bla/>", ())]);
 }
 
 #[test]
 fn test_parse_f64() {
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[
         ("<bla>3.0</bla>", 3.0f64),
         ("<bla>3.1</bla>", 3.1),
@@ -354,7 +359,7 @@ fn test_parse_f64() {
 
 #[test]
 fn test_parse_struct() {
-    let _ = simple_logger::init();
+    init_logger();
 
     test_parse_ok(&[
         (
@@ -401,7 +406,7 @@ fn test_parse_struct() {
 
 #[test]
 fn test_option() {
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[
         ("<a/>", Some("".to_string())),
         ("<a></a>", Some("".to_string())),
@@ -413,13 +418,13 @@ fn test_option() {
 #[test]
 #[ignore] // FIXME
 fn test_option_not_trim() {
-    let _ = simple_logger::init();
+    init_logger();
     test_parse_ok(&[("<a> </a>", Some(" ".to_string()))]);
 }
 
 #[test]
 fn test_amoskvin() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(Debug, Deserialize, PartialEq, Serialize)]
     struct Root {
         foo: Vec<Foo>,
@@ -459,7 +464,7 @@ fn test_amoskvin() {
 #[test]
 #[ignore] // FIXME
 fn test_nicolai86() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct TheSender {
         name: String,
@@ -548,7 +553,7 @@ fn test_nicolai86() {
 
 #[test]
 fn test_hugo_duncan2() {
-    let _ = simple_logger::init();
+    init_logger();
     let s = r#"
     <?xml version="1.0" encoding="UTF-8"?>
     <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
@@ -603,7 +608,7 @@ fn test_hugo_duncan2() {
 
 #[test]
 fn test_hugo_duncan() {
-    let _ = simple_logger::init();
+    init_logger();
     let s = "
         <?xml version=\"1.0\" encoding=\"UTF-8\"?>
         <DescribeInstancesResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">
@@ -628,7 +633,7 @@ fn test_hugo_duncan() {
 
 #[test]
 fn test_parse_xml_value() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(Eq, Debug, PartialEq, Deserialize, Serialize)]
     struct Test {
         #[serde(rename = "$value")]
@@ -645,7 +650,7 @@ fn test_parse_xml_value() {
 #[test]
 #[ignore] // FIXME
 fn test_parse_complexstruct() {
-    let _ = simple_logger::init();
+    init_logger();
 
     test_parse_ok(&[
         (
@@ -689,7 +694,7 @@ fn test_parse_complexstruct() {
 
 #[test]
 fn test_parse_attributes() {
-    let _ = simple_logger::init();
+    init_logger();
 
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     struct A {
@@ -774,7 +779,7 @@ fn test_parse_attributes() {
 #[test]
 #[ignore] // FIXME
 fn test_parse_hierarchies() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     struct A {
         a1: String,
@@ -923,7 +928,7 @@ fn test_things_qc_found() {
 
 #[test]
 fn futile() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
     struct Object {
         id: u8,
@@ -972,7 +977,7 @@ fn futile() {
 
 #[test]
 fn futile2() {
-    let _ = simple_logger::init();
+    init_logger();
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
     struct Null;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,6 +8,11 @@ extern crate simple_logger;
 
 use serde::Deserialize;
 use serde_xml_rs::{from_str, Deserializer};
+use simple_logger::SimpleLogger;
+
+fn init_logger() {
+    let _ = SimpleLogger::new().init();
+}
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Item {
@@ -17,7 +22,7 @@ struct Item {
 
 #[test]
 fn simple_struct_from_attributes() {
-    let _ = simple_logger::init();
+    init_logger();
 
     let s = r##"
         <item name="hello" source="world.rs" />
@@ -36,7 +41,7 @@ fn simple_struct_from_attributes() {
 
 #[test]
 fn multiple_roots_attributes() {
-    let _ = simple_logger::init();
+    init_logger();
 
     let s = r##"
         <item name="hello" source="world.rs" />
@@ -62,7 +67,7 @@ fn multiple_roots_attributes() {
 
 #[test]
 fn simple_struct_from_attribute_and_child() {
-    let _ = simple_logger::init();
+    init_logger();
 
     let s = r##"
         <item name="hello">
@@ -91,7 +96,7 @@ struct Project {
 
 #[test]
 fn nested_collection() {
-    let _ = simple_logger::init();
+    init_logger();
 
     let s = r##"
         <project name="my_project">
@@ -135,7 +140,7 @@ struct MyEnums {
 
 #[test]
 fn collection_of_enums() {
-    let _ = simple_logger::init();
+    init_logger();
 
     let s = r##"
         <enums>
@@ -186,7 +191,7 @@ fn out_of_order_collection() {
         name: String,
     }
 
-    let _ = simple_logger::init();
+    init_logger();
 
     let in_xml = r#"
         <collection>
@@ -246,7 +251,7 @@ fn nested_out_of_order_collection() {
         name: String,
     }
 
-    let _ = simple_logger::init();
+    init_logger();
 
     let in_xml = r#"
         <collection>
@@ -309,7 +314,7 @@ fn out_of_order_tuple() {
         name_c: String,
     }
 
-    let _ = simple_logger::init();
+    init_logger();
 
     let in_xml = r#"
         <collection>
@@ -359,7 +364,7 @@ fn nested_collection_repeated_elements() {
         name: String,
     }
 
-    let _ = simple_logger::init();
+    init_logger();
 
     let in_xml = r#"
         <collection>


### PR DESCRIPTION
Silence warnings:

```
warning: use of deprecated function `simple_logger::init`: Please use the Builder pattern instead.
  --> tests/migrated.rs:86:13
   |
86 |     let _ = simple_logger::init();
   |             ^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```