### PR TITLE
Use the "derive" feature of serde rather than serde_derive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ xml-rs = "0.8"
 thiserror = "1.0"
 
 [dev-dependencies]
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 simple_logger = "1.0"
 docmatic = "0.1"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 ## Example usage
 
 ```rust
-use serde;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_xml_rs::{from_str, to_string};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -22,7 +22,6 @@ mod var;
 ///
 /// ```rust
 /// # #[macro_use]
-/// # extern crate serde_derive;
 /// # extern crate serde;
 /// # extern crate serde_xml_rs;
 /// # use serde_xml_rs::from_str;
@@ -45,7 +44,6 @@ pub fn from_str<'de, T: de::Deserialize<'de>>(s: &str) -> Result<T> {
 ///
 /// ```rust
 /// # #[macro_use]
-/// # extern crate serde_derive;
 /// # extern crate serde;
 /// # extern crate serde_xml_rs;
 /// # use serde_xml_rs::from_reader;
@@ -109,7 +107,6 @@ impl<'de, R: Read> RootDeserializer<R> {
     ///
     /// ```rust
     /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// # extern crate serde;
     /// # extern crate serde_xml_rs;
     /// # use serde_xml_rs::from_reader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,7 @@
 //! ## Basic example
 //!
 //! ```rust
-//! use serde;
-//! use serde_derive::{Deserialize, Serialize};
+//! use serde::{Deserialize, Serialize};
 //! use serde_xml_rs::{from_str, to_string};
 //!
 //! #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -77,8 +76,7 @@
 //! ## Tag contents
 //!
 //! ```rust
-//! # use serde;
-//! # use serde_derive::{Deserialize, Serialize};
+//! # use serde::{self, Deserialize, Serialize};
 //! # use serde_xml_rs::{from_str, to_string};
 //!
 //! #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -102,8 +100,7 @@
 //! ## Repeated tags
 //!
 //! ```rust
-//! # use serde;
-//! # use serde_derive::{Deserialize, Serialize};
+//! # use serde::{self, Deserialize, Serialize};
 //! # use serde_xml_rs::{from_str, to_string};
 //!
 //! #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -160,8 +157,7 @@
 //! ## Custom EventReader
 //!
 //! ```rust
-//! use serde::Deserialize;
-//! use serde_derive::{Deserialize, Serialize};
+//! use serde::{Deserialize, Serialize};
 //! use serde_xml_rs::{from_str, to_string, de::Deserializer};
 //! use xml::reader::{EventReader, ParserConfig};
 //!

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -14,7 +14,6 @@ mod var;
 ///
 /// ```rust
 /// # #[macro_use]
-/// # extern crate serde_derive;
 /// # extern crate serde;
 /// # extern crate serde_xml_rs;
 /// # use serde_xml_rs::to_writer;
@@ -45,7 +44,6 @@ pub fn to_writer<W: Write, S: Serialize>(writer: W, value: &S) -> Result<()> {
 ///
 /// ```rust
 /// # #[macro_use]
-/// # extern crate serde_derive;
 /// # extern crate serde;
 /// # extern crate serde_xml_rs;
 /// # use serde_xml_rs::to_string;
@@ -291,8 +289,7 @@ where
 mod tests {
     use super::*;
     use serde::ser::{SerializeMap, SerializeStruct};
-    use serde::Serializer as SerSerializer;
-    use serde_derive::Serialize;
+    use serde::{Serialize, Serializer as SerSerializer};
 
     #[test]
     fn test_serialize_bool() {

--- a/tests/failures.rs
+++ b/tests/failures.rs
@@ -1,5 +1,5 @@
 use log::info;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use serde_xml_rs::from_str;
 use simple_logger::SimpleLogger;
 

--- a/tests/migrated.rs
+++ b/tests/migrated.rs
@@ -1,8 +1,7 @@
 use simple_logger::SimpleLogger;
 use std::fmt::Debug;
 
-use serde::{de, ser};
-use serde_derive::{Deserialize, Serialize};
+use serde::{de, ser, Deserialize, Serialize};
 use serde_xml_rs::{from_str, Error};
 
 fn init_logger() {

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -1,5 +1,4 @@
-use serde::Deserialize;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_xml_rs::{self, from_str, to_string, EventReader, ParserConfig};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use serde_derive::Deserialize;
 use serde_xml_rs::{from_str, Deserializer};
 use simple_logger::SimpleLogger;
 


### PR DESCRIPTION
This matches the serde crate's documentation on how to use derive.  It also avoids compile failures if new or existing dependencies add this feature to serde.