### PR TITLE
fix: replace debug! logs with trace! in de module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "xml-rs based deserializer for Serde (compatible with 0.9+)"
 license = "MIT"
 name = "serde-xml-rs"
 repository = "https://github.com/RReverser/serde-xml-rs"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2018"
 
 [dependencies]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 use std::{io::Read, marker::PhantomData};
 
-use log::debug;
+use log::trace;
 use serde::de::{self, Unexpected};
 use serde::forward_to_deserialize_any;
 use xml::name::OwnedName;
@@ -154,7 +154,7 @@ impl<'de, R: Read, B: BufferedXmlReader<R>> Deserializer<R, B> {
     fn peek(&mut self) -> Result<&XmlEvent> {
         let peeked = self.buffered_reader.peek()?;
 
-        debug!("Peeked {:?}", peeked);
+        trace!("Peeked {:?}", peeked);
         Ok(peeked)
     }
 
@@ -171,7 +171,7 @@ impl<'de, R: Read, B: BufferedXmlReader<R>> Deserializer<R, B> {
             }
             _ => {}
         }
-        debug!("Fetched {:?}", next);
+        trace!("Fetched {:?}", next);
         Ok(next)
     }
 


### PR DESCRIPTION
It's quite common to want to set log level to debug especially when
using an external logging service. When doing this serde_xml_rs produces
an excessive number of debug logs.
