### PR TITLE
feat: Allow srializer with custom eventwriter

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -100,6 +100,10 @@ where
         Self::new_from_writer(EmitterConfig::new().create_writer(writer))
     }
 
+    pub fn with_writer(writer: EventWriter<W>) -> Self {
+        Self::new_from_writer(writer)
+    }
+
     fn next(&mut self, event: XmlEvent) -> Result<()> {
         self.writer.write(event)?;
         Ok(())

--- a/tests/emiter_config.rs
+++ b/tests/emiter_config.rs
@@ -1,0 +1,26 @@
+use serde::Serialize;
+use serde_xml_rs::Serializer;
+use xml::EmitterConfig;
+
+#[derive(Debug, Serialize, PartialEq)]
+struct Item {
+    name: String,
+    source: String,
+}
+
+#[test]
+fn serializer_should_accept_custom_emitter() {
+    let item = Item {
+        name: "john".to_string(),
+        source: "outerworld".to_string(),
+    };
+    let mut output = Vec::new();
+    {
+        let w = EmitterConfig::default()
+            .perform_indent(true)
+            .create_writer(&mut output);
+        let mut serializer = Serializer::with_writer(w);
+        item.serialize(&mut serializer).unwrap();
+    }
+    assert_eq!("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Item>\n  <name>john</name>\n  <source>outerworld</source>\n</Item>", String::from_utf8_lossy(&output));
+}


### PR DESCRIPTION
This way, one can configure parametes for the xml crate, like indentation.
Any ideas for a shortcut function name? `serde_xml_rs::to_writer_from_event_writer`?