### PR TITLE
feat: Add indexmap to ensure ordering of output xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4"
 serde = "1.0"
 xml-rs = "0.8"
 thiserror = "1.0"
+indexmap = "1.9.1"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -9,9 +9,10 @@ use self::{
     tuple::TupleSerializer,
 };
 use crate::error::{Error, Result};
+use indexmap::IndexMap as HashMap;
 use log::debug;
 use serde::ser::Serialize;
-use std::{collections::HashMap, io::Write};
+use std::io::Write;
 use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
 
 /// A convenience method for serializing some object to a buffer.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::init_logger;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_xml_rs::{from_str, Deserializer};
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -377,4 +377,31 @@ fn nested_collection_repeated_elements() {
     let actual = OuterCollection::deserialize(&mut de).unwrap();
 
     assert_eq!(should_be, actual);
+}
+
+#[test]
+fn attributes_respect_the_original_position() {
+    #[derive(Serialize)]
+    struct OrderedAttributes {
+        #[serde(rename = "@name")]
+        name: &'static str,
+        #[serde(rename = "@position")]
+        position: u64,
+        #[serde(rename = "@size")]
+        size: u64,
+        #[serde(rename = "@active")]
+        active: bool,
+    }
+
+    for _ in 0..10 {
+        let input = OrderedAttributes {
+            name: "han shot",
+            position: 1,
+            size: 1,
+            active: true,
+        };
+        let expected =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><OrderedAttributes name=\"han shot\" position=\"1\" size=\"1\" active=\"true\" />";
+        assert_eq!(expected, serde_xml_rs::to_string(&input).unwrap())
+    }
 }


### PR DESCRIPTION
This helps a lot to avoid shifting position of attributes
