### PR TITLE
Fix Vec<Struct> seralization #186

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -374,7 +374,11 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     }
 
     fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        self.open_root_tag(name)?;
+        if self.root {
+            self.open_root_tag(name)?;
+        } else {
+            self.open_tag(name)?;
+        }
 
         debug!("Struct {}", name);
         Ok(StructSerializer::new(self, false))

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -8,6 +8,12 @@ struct Item {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Items {
+    #[serde(rename = "$value")]
+    items: Vec<Item>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 enum Node {
     Boolean(bool),
     Identifier { value: String, index: u32 },
@@ -33,6 +39,29 @@ fn basic_struct() {
 
     let reserialized_item = to_string(&item).unwrap();
     assert_eq!(src, reserialized_item);
+}
+
+#[test]
+fn round_trip_list_of_structs() {
+    let src = r#"<?xml version="1.0" encoding="UTF-8"?><Items><Item><name>Apple</name><source>Store</source></Item><Item><name>Orange</name><source>Store</source></Item></Items>"#;
+    let should_be = Items {
+        items: vec![
+            Item {
+                name: "Apple".to_string(),
+                source: "Store".to_string(),
+            },
+            Item {
+                name: "Orange".to_string(),
+                source: "Store".to_string(),
+            }
+        ]
+    };
+
+    let items: Items = from_str(src).unwrap();
+    assert_eq!(items, should_be);
+
+    let reserialized_items = to_string(&items).unwrap();
+    assert_eq!(src, reserialized_items);
 }
 
 #[test]


### PR DESCRIPTION
Fixes a bug where open_tag wasn't being for each struct in the sequence.

Addresses #186 