### PR TITLE
bugfix for is_map_value stays true after vec of struct in enum

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -363,6 +363,9 @@ impl<'de, 'a, R: Read, B: BufferedXmlReader<R>> de::Deserializer<'de>
         _variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value> {
+        if let XmlEvent::StartElement { .. } = *self.peek()? {
+            self.unset_map_value();
+        }
         self.read_inner_value::<V, V::Value, _>(|this| visitor.visit_enum(EnumAccess::new(this)))
     }
 

--- a/tests/nested_enum.rs
+++ b/tests/nested_enum.rs
@@ -1,0 +1,93 @@
+mod common;
+
+use common::init_logger;
+use serde::Deserialize;
+use serde_xml_rs::{from_str, Deserializer};
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename = "nesteddef")]
+pub struct NestedDef {
+    #[serde(rename = "$value")]
+    pub definitions: Vec<Definition>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub enum Definition {
+    #[serde(rename = "messageDefinition")]
+    Message(MessageDefinition),
+
+    #[serde(rename = "enumerationDefinition")]
+    Enum(EnumerationDefinition),
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct MessageDefinition {
+    pub name: String,
+
+    #[serde(rename = "$value")]
+    pub fields: Vec<Field>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct EnumerationDefinition {
+    pub name: String,
+
+    #[serde(rename = "entry")]
+    pub entries: Vec<EnumerationVariant>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct EnumerationVariant {
+    pub value: u16,
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub enum Field {
+    #[serde(rename = "field")]
+    Field { name: String },
+}
+
+// this order of XML is broken since 0.5, worked in 0.4.1
+#[test]
+fn vec_of_struct_first_parseable() {
+    init_logger();
+
+    let s = r##"
+        <nesteddef>
+            <enumerationDefinition name="some enum">
+                <entry value="0" name="first" />
+                <entry value="1" name="second" />
+            </enumerationDefinition>
+            <messageDefinition name="msg name">
+                <field name="msg_field1" />
+                <field name="msg_field2" />
+                <field name="msg_field3" />
+            </messageDefinition>
+        </nesteddef>
+    "##;
+
+    let _ok: NestedDef = from_str(s).unwrap();
+}
+
+// this order of xml is parseable since 0.4.1 (potentially earlier did not try)
+#[test]
+fn vec_of_struct_second_parseable() {
+    init_logger();
+
+    let s = r##"
+        <nesteddef>
+            <messageDefinition name="msg name">
+                <field name="msg_field1" />
+                <field name="msg_field2" />
+                <field name="msg_field3" />
+            </messageDefinition>
+            <enumerationDefinition name="some enum">
+                <entry value="0" name="first" />
+                <entry value="1" name="second" />
+            </enumerationDefinition>
+        </nesteddef>
+    "##;
+
+    let _ok: NestedDef = from_str(s).unwrap();
+}


### PR DESCRIPTION
I ran into this head-scratcher today, history:

1. upgraded software that used serde-xml-rs v0.3.0 to use v0.6.0.
2. It compiled fine but parsing broke. 
3. found out that parsing still works on 0.4.1
4. investigated what happens and built a minimal test case
5. the `self.is_map_value` is true after parsing the `<enumerationDefinition>` which when continuing, inside `read_inner_value ()`, skips the StartElement of the next xml item (`<messageDefinition>`) and then is confused because the `enum Definition` has no variant for `<field>` items.
6. changing the order of the XML elements actually makes it parseable again 🤔 

point 6. made me believe this is a bug and `self.is_map_value` should be reset when a new StartElement is coming up for an enum - since I don't fully grok the description what this struct field really does for `read_inner_value()`, please double verify this is all good. All tests succeed, so I guess my fix is fine and has no side-effects?

I'll adapt this patch however needed, I do realise this is more of a bug report including a potential fix than a PR. I'd like to advocate though to keep the test case of this PR at least please :)