### PR TITLE
Fix up unit variant ordering and support rendering them as string content

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,53 @@ fn main() {
     assert_eq!(src, reserialized_item);
 }
 ```
+
+## Tuning the serialization
+
+Since XML has multiple ways to represent "sub-values" of a node (attributes,
+child nodes, contents) the serializer understands various special names for
+fields to steer where and how their contents should be rendered.
+
+```rust
+#[derive(Serialize)]
+struct Node {
+  // Fields with names starting with `@` are rendered as attributes (and must
+  therefore be primitive types)
+  #[serde(rename = "@my_attr")]
+  my_attr: String,
+
+  // Fields renamed to "$value" are rendered as content nodes of the structure
+  (and must also be primitive types)
+  #[serde(rename = "$value")]
+  content: String,
+
+  // Other fields are rendered as child nodes
+  child: String,
+}
+```
+
+The above might get rendered as:
+
+```xml
+<Node my_attr="foo">
+    Hello World!
+    <child>And me too!</child>
+</Node>
+```
+
+Unit-variant `enum` objects can also be rendered in two ways, either as a
+self-closing node or as a string content by default they're rendered as nodes,
+but this can also be tuned:
+
+```rust
+enum Options {
+    Live,
+    #[serde(rename = "@Laugh")]
+    Laugh,
+    #[serde(rename = "@LOVE")]
+    Love,
+}
+```
+
+When an instance of this `enum` is serialized, `Options::Live` renders as
+`<Live />` while `Laugh` renders as `Laugh` and `Love` renders as `LOVE`.


### PR DESCRIPTION
Fixes #207 (by making unit variants responsible for rendering any outstanding `start_tag` before rendering their bodies).

Also adds support for rendering unit variants as string content (which is a common use case for unit-enums, where they represent a choice of primitive values).