### PR TITLE
test: add failing test for nested structure

### DIFF
--- a/tests/nested-failures.rs
+++ b/tests/nested-failures.rs
@@ -1,0 +1,98 @@
+use serde_xml_rs as xml;
+
+#[repr(C)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub enum Value {
+    #[serde(rename = "i32")]
+    I32(i32),
+    #[serde(rename = "struct")]
+    Struct(Struct),
+    #[serde(rename = "array")]
+    Array(Array),
+}
+
+#[repr(C)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub enum Values {
+    #[serde(rename = "value")]
+    Value(Value),
+}
+
+#[repr(C)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct Struct {
+    #[serde(rename = "$value")]
+    members: Vec<Members>,
+}
+
+
+#[repr(C)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct Member {
+    name: String,
+    value: Value,
+}
+
+
+#[repr(C)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub enum Members {
+    #[serde(rename = "member")]
+    Member(Member),
+}
+
+#[repr(C)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub enum Structs {
+    #[serde(rename = "struct")]
+    Struct(Struct),
+}
+
+
+#[repr(C)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct Array {
+    data: Vec<Values>,
+}
+
+#[test]
+fn nested_struct() -> Result<(), xml::Error> {
+    let exp_xml = r#"<?xml version="1.0"?>
+    <value>
+      <struct>
+        <member>
+          <name>outerStruct</name>
+          <value>
+            <array>
+              <data>
+                <value>
+                  <struct>
+                    <member>
+                      <name>innerStruct</name>
+                      <value>
+                        <array>
+                          <data>
+                            <value>
+                              <i32>0</i32>
+                            </value>
+                            <value>
+                              <i32>1</i32>
+                            </value>
+                          </data>
+                        </array>
+                      </value>
+                    </member>
+                  </struct>
+                </value>
+              </data>
+            </array>
+          </value>
+        </member>
+      </struct>
+    </value>
+    "#;
+
+    xml::from_str::<Values>(exp_xml)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a failing integration test for nested structures that contain repeating keys.

`xml-rs` appears to not be able to find an ending XML token in the nested inner structure when it contains an `array` type with multiple `value`s.

Error from the test `tests/nested-failures.rs`:

```
$ cargo test --test nested-failures
    Updating crates.io index
    Finished test [unoptimized + debuginfo] target(s) in 2.28s
     Running tests/nested-failures.rs (target/debug/deps/nested_failures-966734fbe6baaf5e)

running 1 test
test nested_struct ... FAILED

failures:

---- nested_struct stdout ----
Error: UnexpectedToken { token: "XmlEvent::EndElement { name, .. }", found: "StartElement(value, {\"\": \"\", \"xml\": \"http://www.w3.org/XML/1998/namespace\", \"xmlns\": \"http://www.w3.org/2000/xmlns/\"})" }


failures:
    nested_struct

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `--test nested-failures`
```