### PR TITLE
Temporary fix for namespaces

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -44,8 +44,9 @@ impl<'de, 'a, R: 'a + Read, B: BufferedXmlReader<R>> de::MapAccess<'de> for MapA
             // Read all attributes first
             Some(OwnedAttribute { name, value }) => {
                 self.next_attr_value = Some(value);
-                seed.deserialize(name.local_name.into_deserializer())
-                    .map(Some)
+                let attr_name =
+                    name.prefix.map(|p| p + ":").unwrap_or(String::new()) + &name.local_name;
+                seed.deserialize(attr_name.into_deserializer()).map(Some)
             }
             None => match *self.de.peek()? {
                 XmlEvent::StartElement { ref name, .. } => seed


### PR DESCRIPTION
I am trying to parse a file that has namespaces in attributes e.g `something:attrname="value"` and `attrname="othervalue"` and my struct contains a field `attrname`. serde-xml-rs fails to parse this because `attrname` is duplicate and this happens because it drops the namespaces before the colon.

I've modified it so that it includes the namespace in the attribute name as if the colon is a normal character.