### PR TITLE
fix should_be to be uppercase in test_serialize_enum

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -436,7 +436,7 @@ mod tests {
         }
 
         let mut buffer = Vec::new();
-        let should_be = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Boolean>true</Boolean>";
+        let should_be = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Boolean>true</Boolean>";
 
         {
             let mut ser = Serializer::new(&mut buffer);


### PR DESCRIPTION
test_serialize_enum failed due to encoding was lowercase. Just make it uppercase to pass the test