### PR TITLE
:bug: Serialize attributes in Vector

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -132,11 +132,6 @@ where
         Ok(())
     }
 
-    fn reopen_tag(&mut self) -> Result<()> {
-        self.current_tag_attrs = Some(HashMap::new());
-        Ok(())
-    }
-
     fn abandon_tag(&mut self) -> Result<()> {
         self.current_tag = "".into();
         self.current_tag_attrs = None;

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -21,12 +21,9 @@ impl<'ser, W: 'ser + Write> serde::ser::SerializeSeq for SeqSeralizer<'ser, W> {
     where
         T: ?Sized + Serialize,
     {
-        let must_close_tag = self.ser.build_start_tag()?;
+        let seq_tag = self.ser.current_tag();
         value.serialize(&mut *self.ser)?;
-        if must_close_tag {
-            self.ser.end_tag()?;
-            self.ser.reopen_tag()?;
-        }
+        self.ser.open_tag(&seq_tag)?;
         Ok(())
     }
 

--- a/tests/datatypes.rs
+++ b/tests/datatypes.rs
@@ -146,4 +146,63 @@ mod ser {
             format!(r#"<?xml version="1.0" encoding="UTF-8"?>{}"#, expected)
         );
     }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename = "bar")]
+    struct DummyAttributeVec<T> {
+        bla: Vec<DummyAttribute<T>>,
+    }
+
+    #[rstest]
+    #[case(r#"<bar><bla value="apple" /><bla value="banana" /></bar>"#, vec!["apple", "banana"])]
+    fn attribute_vec_ok(_logger: (), #[case] expected: &str, #[case] value: Vec<&str>) {
+        let actual = to_string(&DummyAttributeVec {
+            bla: vec![
+                DummyAttribute { value: value[0] },
+                DummyAttribute { value: value[1] },
+            ],
+        })
+        .unwrap();
+        assert_eq!(
+            actual,
+            format!(r#"<?xml version="1.0" encoding="UTF-8"?>{}"#, expected)
+        );
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename = "bar")]
+    struct DummyAttributeDummyVec<T> {
+        bla: Vec<DummyAttributeDummy<T>>,
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename = "bla")]
+    struct DummyAttributeDummy<T> {
+        #[serde(rename = "@attr")]
+        attr: T,
+        #[serde(rename = "foo")]
+        dummy: Dummy<T>,
+    }
+
+    #[rstest]
+    #[case(r#"<bar><bla attr="apple"><foo>apple</foo></bla><bla attr="banana"><foo>banana</foo></bla></bar>"#, vec!["apple", "banana"])]
+    fn attribute_vec2_ok(_logger: (), #[case] expected: &str, #[case] value: Vec<&str>) {
+        let actual = to_string(&DummyAttributeDummyVec {
+            bla: vec![
+                DummyAttributeDummy {
+                    attr: value[0],
+                    dummy: Dummy { value: value[0] },
+                },
+                DummyAttributeDummy {
+                    attr: value[1],
+                    dummy: Dummy { value: value[1] },
+                },
+            ],
+        })
+        .unwrap();
+        assert_eq!(
+            actual,
+            format!(r#"<?xml version="1.0" encoding="UTF-8"?>{}"#, expected)
+        );
+    }
 }


### PR DESCRIPTION
Serialize to tags with attribute does not work if they are in a vector, while deserialize of them are supported. Simplify the serialize_element to be able to serialize regardless of the presence of attributes.