### PR TITLE
Defer document declaration generation to xml-rs crate

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -438,4 +438,34 @@ mod tests {
         let got = String::from_utf8(buffer).unwrap();
         assert_eq!(got, should_be);
     }
+
+    #[test]
+    fn test_serialize_struct_no_declaration() {
+        // Verify that document declaration obeys the EmitterConfig.
+
+        #[derive(Serialize)]
+        struct Person {
+            name: String,
+            age: u32,
+        }
+
+        let bob = Person {
+            name: "Bob".to_string(),
+            age: 42,
+        };
+        let should_be = "<Person><name>Bob</name><age>42</age></Person>";
+        let mut buffer = Vec::new();
+
+        let writer = EmitterConfig::new()
+            .write_document_declaration(false)
+            .create_writer(&mut buffer);
+
+        {
+            let mut ser = Serializer::new_from_writer(writer);
+            bob.serialize(&mut ser).unwrap();
+        }
+
+        let got = String::from_utf8(buffer).unwrap();
+        assert_eq!(got, should_be);
+    }
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -109,18 +109,9 @@ where
         self.next(XmlEvent::characters(s))
     }
 
-    fn start_document(&mut self) -> Result<()> {
-        self.next(XmlEvent::StartDocument {
-            encoding: Default::default(),
-            standalone: Default::default(),
-            version: xml::common::XmlVersion::Version10,
-        })
-    }
-
     fn open_root_tag(&mut self, name: &'static str) -> Result<()> {
         if self.root {
             self.root = false;
-            self.start_document()?;
             self.open_tag(name)?;
         }
         Ok(())


### PR DESCRIPTION
`xml-rs` tracks if a document declaration has been emitted yet and will emit one before the starting element if the configuration indicates it. By manually emitting a document declaration in `serde-xml-rs`, users are unable to disable the document declaration itself.

All existing tests pass (because `xml-rs` is taking care of emitting the declaration for us) and I added a new test to verify that the document declaration option in the `EmitterConfig` is being followed correctly.