### PR TITLE
🔧 update thiserror dependency to version 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 log = "0.4"
 serde = "1.0"
 xml-rs = "0.8"
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This pull request updates the dependency version for `thiserror` in the `Cargo.toml` file.